### PR TITLE
Update playwright.yml | Switch to Bun for Dependency Management in Workflows | Switch to Bun for Playwright Installation and Testing

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -16,9 +16,9 @@ jobs:
       - name: Install dependencies
         run: bun install
       - name: Install Playwright Browsers
-        run: npx playwright install --with-deps
+        run: bunx playwright install --with-deps
       - name: Run Playwright tests
-        run: npx playwright test
+        run: bunx playwright test
       - uses: actions/upload-artifact@v4
         if: ${{ !cancelled() }}
         with:

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -14,7 +14,7 @@ jobs:
         with:
           node-version: lts/*
       - name: Install dependencies
-        run: npm ci
+        run: bun install
       - name: Install Playwright Browsers
         run: npx playwright install --with-deps
       - name: Run Playwright tests


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Use bun to install dependencies instead of npm.