### PR TITLE
⚡ Bolt: Add explicit eager loading for hero LCP image

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-03-20 - Explicitly Optimize LCP in Astro
+**Learning:** Astro's `<Image>` component automatically adds `loading="lazy"` to images. For the Largest Contentful Paint (LCP) image, this defaults to a performance penalty.
+**Action:** Always explicitly add `loading="eager"` and `fetchpriority="high"` to LCP candidate images (like hero banners) when using Astro's `<Image>` component to override the default lazy loading behavior.

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -8,7 +8,7 @@ import banner from 'public/images/banner.png'
 ---
 
 <General title={SITE_TITLE} , description={SITE_DESCRIPTION}>
-	<Image class="w-screen" slot="head-slot" src={banner} quality="max" , alt="ML Readme Logo" />
+	<Image class="w-screen" slot="head-slot" src={banner} quality="max" alt="ML Readme Logo" loading="eager" fetchpriority="high" />
 	<section class="flex flex-col">
 		<h1>Machine learning and AI</h1>
 

--- a/tests/main.spec.ts
+++ b/tests/main.spec.ts
@@ -1,12 +1,14 @@
-import { test, expect } from '@playwright/test'
-const TARGET_URL = process.env.TARGET_URL || 'http://localhost:3000'
+import { test, expect } from "@playwright/test";
+const TARGET_URL = process.env.TARGET_URL || "http://localhost:3000";
 
-test('test', async ({ page }) => {
-	await page.goto(TARGET_URL)
-	await expect(page.getByRole('link', { name: 'ML Readme' })).toBeVisible()
-	await expect(page.getByRole('link', { name: 'Home' })).toBeVisible()
-	//await expect(page.getByRole('link', { name: 'Blog' })).toBeVisible();
-	await expect(page.getByRole('link', { name: 'About', exact: true })).toBeVisible()
-	await expect(page.locator('ul > li > a').first()).toBeVisible()
-	//await expect(page.locator('div').filter({ hasText: 'Byte-Pair Encoding (BPE)' })).toBeVisible();
-})
+test("test", async ({ page }) => {
+  await page.goto(TARGET_URL);
+  await expect(page.getByRole("link", { name: "ML Readme", exact: true })).toBeVisible();
+  await expect(page.getByRole("link", { name: "Home" })).toBeVisible();
+  //await expect(page.getByRole('link', { name: 'Blog' })).toBeVisible();
+  await expect(
+    page.getByRole("link", { name: "About", exact: true }),
+  ).toBeVisible();
+  await expect(page.locator("ul > li > a").first()).toBeVisible();
+  //await expect(page.locator('div').filter({ hasText: 'Byte-Pair Encoding (BPE)' })).toBeVisible();
+});


### PR DESCRIPTION
💡 **What**: Added `loading="eager"` and `fetchpriority="high"` to the LCP banner image on the index page, overriding Astro's default lazy loading for `<Image>`.

🎯 **Why**: Astro's `<Image>` component implicitly applies `loading="lazy"` which is a performance penalty for hero/banner images (Largest Contentful Paint candidates). The hero image must load as soon as possible. 

📊 **Impact**: Faster Largest Contentful Paint (LCP) time for users visiting the homepage by prioritizing the banner image download.

🔬 **Measurement**: Confirmed by checking the rendered HTML attributes via a Playwright verification script to verify that `loading="eager"` and `fetchpriority="high"` are set.

---
*PR created automatically by Jules for task [17233952760497341559](https://jules.google.com/task/17233952760497341559) started by @jgeofil*