### PR TITLE
🛡️ Sentinel: [HIGH] Fix XSS vulnerability in HLine component

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-24 - [Astro set:html XSS in Shared Components]
+**Vulnerability:** Found a Cross-Site Scripting (XSS) vulnerability in `src/components/base/HLine.astro` where the `tagline` and `title` props were unsafely interpolated into an HTML string and rendered using Astro's `set:html`.
+**Learning:** Astro's `set:html` directive bypasses its default XSS protection and HTML escaping. When shared components use it to render props (like headers or taglines), they become vulnerable if that data ever comes from user input (e.g., from a CMS, database, or URL params). Even if currently used with static strings, it's a dormant security risk that violates defense in depth.
+**Prevention:** Avoid `set:html` unless absolutely necessary (e.g., rendering markdown). Instead, use standard JSX/Astro syntax for dynamic variable interpolation, which safely HTML-escapes content by default.

--- a/src/components/base/HLine.astro
+++ b/src/components/base/HLine.astro
@@ -1,11 +1,9 @@
 ---
 const { tagline = 'Section 1', center = 'c' } = Astro.props
-
-const text = `<span class="px-5 pr-6 ${center == 'c' ? 'shrink-0' : ''}">${tagline}</span>`
 ---
 
 <span class="flex items-center">
 	{center == 'r' || center == 'c' ? <span class="h-px flex-1 bg-black" /> : ''}
-	<span set:html={text} />
+	<span class={`px-5 pr-6 ${center == 'c' ? 'shrink-0' : ''}`}>{tagline}</span>
 	{center == 'l' || center == 'c' ? <span class="h-px flex-1 bg-black" /> : ''}
 </span>

--- a/tests/main.spec.ts
+++ b/tests/main.spec.ts
@@ -3,7 +3,7 @@ const TARGET_URL = process.env.TARGET_URL || 'http://localhost:3000'
 
 test('test', async ({ page }) => {
 	await page.goto(TARGET_URL)
-	await expect(page.getByRole('link', { name: 'ML Readme' })).toBeVisible()
+	await expect(page.getByRole('link', { name: 'ML Readme', exact: true })).toBeVisible()
 	await expect(page.getByRole('link', { name: 'Home' })).toBeVisible()
 	//await expect(page.getByRole('link', { name: 'Blog' })).toBeVisible();
 	await expect(page.getByRole('link', { name: 'About', exact: true })).toBeVisible()


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Potential Cross-Site Scripting (XSS) vulnerability was found in `src/components/base/HLine.astro`. The `tagline` prop was unsafely concatenated into an HTML string and rendered using Astro's `set:html` directive, bypassing XSS protection. 
🎯 Impact: If the tagline prop ever contained unsanitized user input (from CMS, URL params, or database), it could allow arbitrary script execution in the context of the user's browser, enabling session hijacking or unauthorized actions.
🔧 Fix: Removed `set:html` and refactored the component to use standard JSX/Astro variables for dynamic interpolation, which safely HTML-escapes content by default.
✅ Verification: Ran `bun run lint` and `bun run test` (fixed a flaky strict mode Playwright test in the process). Verified visually with `bun run dev` and Playwright screenshots to ensure the UI remains fully intact after the JSX refactor. Logged the learning to `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [7365044830098973580](https://jules.google.com/task/7365044830098973580) started by @jgeofil*