### PR TITLE
⚡ Bolt: Cache Supabase query for socials on SSR pages

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-24 - Cache Supabase queries on SSR pages
+**Learning:** Shared components (like `Footer.astro`) on SSR pages (`export const prerender = false`) will execute their Supabase queries on every single request. In Astro, these pages run server-side rendering, leading to N redundant requests for the same exact data if not cached.
+**Action:** Always implement an in-memory or Redis caching layer (e.g., `getCachedSocials()`) for frequently queried, relatively static data used in shared components on SSR pages.

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -1,6 +1,6 @@
 ---
 import Icon from "./base/Icon.astro";
-import { supabase, type Socials } from "@db/supabase";
+import { getCachedSocials, type Socials } from "@db/supabase";
 import Social from "./utilities/Social.astro";
 const today = new Date();
 
@@ -18,10 +18,7 @@ const {
 	],
 } = Astro.props;
 
-const { data, error } = await supabase
-	.from("socials")
-	.select()
-	.returns<Socials[]>();
+const { data, error } = await getCachedSocials();
 ---
 
 <footer class="w-full h-full bg-neutral-100">

--- a/src/db/supabase.ts
+++ b/src/db/supabase.ts
@@ -160,3 +160,25 @@ export type CompositeTypes<
 
 export type Categories = Tables<'categories'>
 export type Socials = Tables<'socials'>
+
+// Cache for socials query to avoid redundant requests on SSR pages
+let cachedSocials: { data: Socials[] | null; error: any | null } | null = null;
+let lastFetchTime = 0;
+const CACHE_TTL = 60 * 1000; // 1 minute
+
+export async function getCachedSocials() {
+	const now = Date.now();
+	if (cachedSocials && (now - lastFetchTime < CACHE_TTL)) {
+		return cachedSocials;
+	}
+
+	const result = await supabase
+		.from("socials")
+		.select()
+		.returns<Socials[]>();
+
+	cachedSocials = result;
+	lastFetchTime = now;
+
+	return result;
+}

--- a/tests/main.spec.ts
+++ b/tests/main.spec.ts
@@ -3,7 +3,7 @@ const TARGET_URL = process.env.TARGET_URL || 'http://localhost:3000'
 
 test('test', async ({ page }) => {
 	await page.goto(TARGET_URL)
-	await expect(page.getByRole('link', { name: 'ML Readme' })).toBeVisible()
+	await expect(page.getByRole('link', { name: 'ML Readme', exact: true })).toBeVisible()
 	await expect(page.getByRole('link', { name: 'Home' })).toBeVisible()
 	//await expect(page.getByRole('link', { name: 'Blog' })).toBeVisible();
 	await expect(page.getByRole('link', { name: 'About', exact: true })).toBeVisible()


### PR DESCRIPTION
## 💡 What
Added an in-memory caching function (`getCachedSocials`) for the `socials` Supabase query in `src/db/supabase.ts`, and updated the `Footer.astro` component to use it. Also updated strict mode test locator in `main.spec.ts`.

## 🎯 Why
Shared components (like `Footer.astro`) on SSR pages (`export const prerender = false`) execute their Supabase queries on every single request. Without caching, this results in multiple redundant database queries per request, negatively impacting TTFB and generating unnecessary database load.

## 📊 Impact
Reduces database calls for the `socials` table to just once per minute (via TTL), down from one per page load, thus optimizing SSR rendering speed.

## 🔬 Measurement
Ensure tests pass locally with `SUPABASE_URL="http://localhost:5432" SUPABASE_KEY="anon" bun run test`. A local network inspection when loading an SSR page like `index.astro` multiple times should confirm only 1 request goes to Supabase per minute.

---
*PR created automatically by Jules for task [10544483596854519161](https://jules.google.com/task/10544483596854519161) started by @jgeofil*