### PR TITLE
⚡ Bolt: Add in-memory cache for SSR socials queries

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,4 @@
+## 2024-03-16 - Prevent Redundant Database Queries on SSR Pages
+
+**Learning:** Shared components (like `Footer.astro`) on Server-Side Rendered (SSR) pages execute their Supabase queries on every request. This creates a significant N+1-like performance bottleneck when the data is relatively static.
+**Action:** Always implement an in-memory caching layer (e.g., with a TTL) in `src/db/supabase.ts` for these shared queries to prevent redundant database load and improve response times.

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -1,6 +1,6 @@
 ---
 import Icon from "./base/Icon.astro";
-import { supabase, type Socials } from "@db/supabase";
+import { getCachedSocials, type Socials } from "@db/supabase";
 import Social from "./utilities/Social.astro";
 const today = new Date();
 
@@ -18,10 +18,7 @@ const {
 	],
 } = Astro.props;
 
-const { data, error } = await supabase
-	.from("socials")
-	.select()
-	.returns<Socials[]>();
+const { data, error } = await getCachedSocials();
 ---
 
 <footer class="w-full h-full bg-neutral-100">

--- a/src/db/supabase.ts
+++ b/src/db/supabase.ts
@@ -1,4 +1,3 @@
-
 import { createClient } from "@supabase/supabase-js";
 
 const supabaseUrl = import.meta.env.SUPABASE_URL;
@@ -6,157 +5,204 @@ const supabaseKey = import.meta.env.SUPABASE_KEY;
 
 export const supabase = createClient(supabaseUrl, supabaseKey);
 
-export type Json = string | number | boolean | null | { [key: string]: Json | undefined } | Json[]
+// In-memory cache for socials query (frequently accessed in SSR Footer component)
+let cachedSocials: any = null;
+let cachedSocialsTimestamp = 0;
+const CACHE_TTL_MS = 60 * 1000; // 60 seconds
 
-export type Database = {
-	public: {
-		Tables: {
-			categories: {
-				Row: {
-					children: number[] | null
-					created_at: string
-					description: string | null
-					id: number
-					name: string | null
-					top: boolean | null
-				}
-				Insert: {
-					children?: number[] | null
-					created_at?: string
-					description?: string | null
-					id?: number
-					name?: string | null
-					top?: boolean | null
-				}
-				Update: {
-					children?: number[] | null
-					created_at?: string
-					description?: string | null
-					id?: number
-					name?: string | null
-					top?: boolean | null
-				}
-				Relationships: []
-			}
-			socials: {
-				Row: {
-					color: string
-					created_at: string
-					id: number
-					name: string
-					profile: string | null
-					url: string | null
-				}
-				Insert: {
-					color: string
-					created_at?: string
-					id?: number
-					name: string
-					profile?: string | null
-					url?: string | null
-				}
-				Update: {
-					color?: string
-					created_at?: string
-					id?: number
-					name?: string
-					profile?: string | null
-					url?: string | null
-				}
-				Relationships: []
-			}
-		}
-		Views: {
-			[_ in never]: never
-		}
-		Functions: {
-			[_ in never]: never
-		}
-		Enums: {
-			[_ in never]: never
-		}
-		CompositeTypes: {
-			[_ in never]: never
-		}
-	}
+export async function getCachedSocials() {
+  const now = Date.now();
+  if (cachedSocials && now - cachedSocialsTimestamp < CACHE_TTL_MS) {
+    return cachedSocials;
+  }
+
+  const result = await supabase.from("socials").select().returns<Socials[]>();
+
+  if (!result.error) {
+    cachedSocials = result;
+    cachedSocialsTimestamp = now;
+  }
+
+  return result;
 }
 
-type PublicSchema = Database[Extract<keyof Database, 'public'>]
+export type Json =
+  | string
+  | number
+  | boolean
+  | null
+  | { [key: string]: Json | undefined }
+  | Json[];
+
+export type Database = {
+  public: {
+    Tables: {
+      categories: {
+        Row: {
+          children: number[] | null;
+          created_at: string;
+          description: string | null;
+          id: number;
+          name: string | null;
+          top: boolean | null;
+        };
+        Insert: {
+          children?: number[] | null;
+          created_at?: string;
+          description?: string | null;
+          id?: number;
+          name?: string | null;
+          top?: boolean | null;
+        };
+        Update: {
+          children?: number[] | null;
+          created_at?: string;
+          description?: string | null;
+          id?: number;
+          name?: string | null;
+          top?: boolean | null;
+        };
+        Relationships: [];
+      };
+      socials: {
+        Row: {
+          color: string;
+          created_at: string;
+          id: number;
+          name: string;
+          profile: string | null;
+          url: string | null;
+        };
+        Insert: {
+          color: string;
+          created_at?: string;
+          id?: number;
+          name: string;
+          profile?: string | null;
+          url?: string | null;
+        };
+        Update: {
+          color?: string;
+          created_at?: string;
+          id?: number;
+          name?: string;
+          profile?: string | null;
+          url?: string | null;
+        };
+        Relationships: [];
+      };
+    };
+    Views: {
+      [_ in never]: never;
+    };
+    Functions: {
+      [_ in never]: never;
+    };
+    Enums: {
+      [_ in never]: never;
+    };
+    CompositeTypes: {
+      [_ in never]: never;
+    };
+  };
+};
+
+type PublicSchema = Database[Extract<keyof Database, "public">];
 
 export type Tables<
-	PublicTableNameOrOptions extends keyof (PublicSchema['Tables'] & PublicSchema['Views']) | { schema: keyof Database },
-	TableName extends PublicTableNameOrOptions extends { schema: keyof Database }
-		? keyof (Database[PublicTableNameOrOptions['schema']]['Tables'] & Database[PublicTableNameOrOptions['schema']]['Views'])
-		: never = never
+  PublicTableNameOrOptions extends
+    | keyof (PublicSchema["Tables"] & PublicSchema["Views"])
+    | { schema: keyof Database },
+  TableName extends PublicTableNameOrOptions extends { schema: keyof Database }
+    ? keyof (Database[PublicTableNameOrOptions["schema"]]["Tables"] &
+        Database[PublicTableNameOrOptions["schema"]]["Views"])
+    : never = never,
 > = PublicTableNameOrOptions extends { schema: keyof Database }
-	? (Database[PublicTableNameOrOptions['schema']]['Tables'] & Database[PublicTableNameOrOptions['schema']]['Views'])[TableName] extends {
-			Row: infer R
-		}
-		? R
-		: never
-	: PublicTableNameOrOptions extends keyof (PublicSchema['Tables'] & PublicSchema['Views'])
-		? (PublicSchema['Tables'] & PublicSchema['Views'])[PublicTableNameOrOptions] extends {
-				Row: infer R
-			}
-			? R
-			: never
-		: never
+  ? (Database[PublicTableNameOrOptions["schema"]]["Tables"] &
+      Database[PublicTableNameOrOptions["schema"]]["Views"])[TableName] extends {
+      Row: infer R;
+    }
+    ? R
+    : never
+  : PublicTableNameOrOptions extends keyof (PublicSchema["Tables"] &
+        PublicSchema["Views"])
+    ? (PublicSchema["Tables"] &
+        PublicSchema["Views"])[PublicTableNameOrOptions] extends {
+        Row: infer R;
+      }
+      ? R
+      : never
+    : never;
 
 export type TablesInsert<
-	PublicTableNameOrOptions extends keyof PublicSchema['Tables'] | { schema: keyof Database },
-	TableName extends PublicTableNameOrOptions extends { schema: keyof Database } ? keyof Database[PublicTableNameOrOptions['schema']]['Tables'] : never = never
+  PublicTableNameOrOptions extends
+    | keyof PublicSchema["Tables"]
+    | { schema: keyof Database },
+  TableName extends PublicTableNameOrOptions extends { schema: keyof Database }
+    ? keyof Database[PublicTableNameOrOptions["schema"]]["Tables"]
+    : never = never,
 > = PublicTableNameOrOptions extends { schema: keyof Database }
-	? Database[PublicTableNameOrOptions['schema']]['Tables'][TableName] extends {
-			Insert: infer I
-		}
-		? I
-		: never
-	: PublicTableNameOrOptions extends keyof PublicSchema['Tables']
-		? PublicSchema['Tables'][PublicTableNameOrOptions] extends {
-				Insert: infer I
-			}
-			? I
-			: never
-		: never
+  ? Database[PublicTableNameOrOptions["schema"]]["Tables"][TableName] extends {
+      Insert: infer I;
+    }
+    ? I
+    : never
+  : PublicTableNameOrOptions extends keyof PublicSchema["Tables"]
+    ? PublicSchema["Tables"][PublicTableNameOrOptions] extends {
+        Insert: infer I;
+      }
+      ? I
+      : never
+    : never;
 
 export type TablesUpdate<
-	PublicTableNameOrOptions extends keyof PublicSchema['Tables'] | { schema: keyof Database },
-	TableName extends PublicTableNameOrOptions extends { schema: keyof Database } ? keyof Database[PublicTableNameOrOptions['schema']]['Tables'] : never = never
+  PublicTableNameOrOptions extends
+    | keyof PublicSchema["Tables"]
+    | { schema: keyof Database },
+  TableName extends PublicTableNameOrOptions extends { schema: keyof Database }
+    ? keyof Database[PublicTableNameOrOptions["schema"]]["Tables"]
+    : never = never,
 > = PublicTableNameOrOptions extends { schema: keyof Database }
-	? Database[PublicTableNameOrOptions['schema']]['Tables'][TableName] extends {
-			Update: infer U
-		}
-		? U
-		: never
-	: PublicTableNameOrOptions extends keyof PublicSchema['Tables']
-		? PublicSchema['Tables'][PublicTableNameOrOptions] extends {
-				Update: infer U
-			}
-			? U
-			: never
-		: never
+  ? Database[PublicTableNameOrOptions["schema"]]["Tables"][TableName] extends {
+      Update: infer U;
+    }
+    ? U
+    : never
+  : PublicTableNameOrOptions extends keyof PublicSchema["Tables"]
+    ? PublicSchema["Tables"][PublicTableNameOrOptions] extends {
+        Update: infer U;
+      }
+      ? U
+      : never
+    : never;
 
 export type Enums<
-	PublicEnumNameOrOptions extends keyof PublicSchema['Enums'] | { schema: keyof Database },
-	EnumName extends PublicEnumNameOrOptions extends { schema: keyof Database } ? keyof Database[PublicEnumNameOrOptions['schema']]['Enums'] : never = never
+  PublicEnumNameOrOptions extends
+    | keyof PublicSchema["Enums"]
+    | { schema: keyof Database },
+  EnumName extends PublicEnumNameOrOptions extends { schema: keyof Database }
+    ? keyof Database[PublicEnumNameOrOptions["schema"]]["Enums"]
+    : never = never,
 > = PublicEnumNameOrOptions extends { schema: keyof Database }
-	? Database[PublicEnumNameOrOptions['schema']]['Enums'][EnumName]
-	: PublicEnumNameOrOptions extends keyof PublicSchema['Enums']
-		? PublicSchema['Enums'][PublicEnumNameOrOptions]
-		: never
+  ? Database[PublicEnumNameOrOptions["schema"]]["Enums"][EnumName]
+  : PublicEnumNameOrOptions extends keyof PublicSchema["Enums"]
+    ? PublicSchema["Enums"][PublicEnumNameOrOptions]
+    : never;
 
 export type CompositeTypes<
-	PublicCompositeTypeNameOrOptions extends keyof PublicSchema['CompositeTypes'] | { schema: keyof Database },
-	CompositeTypeName extends PublicCompositeTypeNameOrOptions extends {
-		schema: keyof Database
-	}
-		? keyof Database[PublicCompositeTypeNameOrOptions['schema']]['CompositeTypes']
-		: never = never
+  PublicCompositeTypeNameOrOptions extends
+    | keyof PublicSchema["CompositeTypes"]
+    | { schema: keyof Database },
+  CompositeTypeName extends PublicCompositeTypeNameOrOptions extends {
+    schema: keyof Database;
+  }
+    ? keyof Database[PublicCompositeTypeNameOrOptions["schema"]]["CompositeTypes"]
+    : never = never,
 > = PublicCompositeTypeNameOrOptions extends { schema: keyof Database }
-	? Database[PublicCompositeTypeNameOrOptions['schema']]['CompositeTypes'][CompositeTypeName]
-	: PublicCompositeTypeNameOrOptions extends keyof PublicSchema['CompositeTypes']
-		? PublicSchema['CompositeTypes'][PublicCompositeTypeNameOrOptions]
-		: never
+  ? Database[PublicCompositeTypeNameOrOptions["schema"]]["CompositeTypes"][CompositeTypeName]
+  : PublicCompositeTypeNameOrOptions extends keyof PublicSchema["CompositeTypes"]
+    ? PublicSchema["CompositeTypes"][PublicCompositeTypeNameOrOptions]
+    : never;
 
-export type Categories = Tables<'categories'>
-export type Socials = Tables<'socials'>
+export type Categories = Tables<"categories">;
+export type Socials = Tables<"socials">;

--- a/tests/main.spec.ts
+++ b/tests/main.spec.ts
@@ -1,12 +1,14 @@
-import { test, expect } from '@playwright/test'
-const TARGET_URL = process.env.TARGET_URL || 'http://localhost:3000'
+import { test, expect } from "@playwright/test";
+const TARGET_URL = process.env.TARGET_URL || "http://localhost:3000";
 
-test('test', async ({ page }) => {
-	await page.goto(TARGET_URL)
-	await expect(page.getByRole('link', { name: 'ML Readme' })).toBeVisible()
-	await expect(page.getByRole('link', { name: 'Home' })).toBeVisible()
-	//await expect(page.getByRole('link', { name: 'Blog' })).toBeVisible();
-	await expect(page.getByRole('link', { name: 'About', exact: true })).toBeVisible()
-	await expect(page.locator('ul > li > a').first()).toBeVisible()
-	//await expect(page.locator('div').filter({ hasText: 'Byte-Pair Encoding (BPE)' })).toBeVisible();
-})
+test("test", async ({ page }) => {
+  await page.goto(TARGET_URL);
+  await expect(page.getByRole("link", { name: "ML Readme", exact: true })).toBeVisible();
+  await expect(page.getByRole("link", { name: "Home" })).toBeVisible();
+  //await expect(page.getByRole('link', { name: 'Blog' })).toBeVisible();
+  await expect(
+    page.getByRole("link", { name: "About", exact: true }),
+  ).toBeVisible();
+  await expect(page.locator("ul > li > a").first()).toBeVisible();
+  //await expect(page.locator('div').filter({ hasText: 'Byte-Pair Encoding (BPE)' })).toBeVisible();
+});


### PR DESCRIPTION
💡 **What:** Added an in-memory caching layer (`getCachedSocials` with a 60-second TTL) for the Supabase `socials` table query in `src/db/supabase.ts` and updated `src/components/Footer.astro` to use this new function. Created `.jules/bolt.md` to document this architectural pattern.
🎯 **Why:** Shared components like `Footer.astro` execute their Supabase queries on every request for SSR pages (e.g. `index.astro` which has `prerender = false`), creating an N+1-like performance bottleneck. Caching prevents redundant database load.
📊 **Impact:** Reduces database load by preventing a database call for `socials` on every page load for SSR pages (cached for 60s). It makes the response times faster across those pages.
🔬 **Measurement:** Verify by measuring Time to First Byte (TTFB) or checking Supabase query logs to see a significant reduction in `socials` SELECT queries per minute.

---
*PR created automatically by Jules for task [15458745205561542756](https://jules.google.com/task/15458745205561542756) started by @jgeofil*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced automatic caching layer for shared database queries with configurable refresh intervals, reducing redundant server requests and improving page load times.

* **Refactor**
  * Enhanced database type definitions and internal schema organization for improved code structure and clarity.

* **Tests**
  * Applied consistent formatting standards to test files, including quote style normalization and indentation adjustments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->