### PR TITLE
⚡ Bolt: Cache Supabase queries in shared SSR components

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,5 @@
+## 2024-05-01 - Shared Components Executing DB Queries on SSR Pages
+
+**Learning:** Shared components (like `Footer.astro`) on SSR pages execute their Supabase queries on every single request. If these queries fetch relatively static data, this becomes a huge architectural bottleneck causing redundant database load and increased latency.
+
+**Action:** Implement an in-memory caching layer with a TTL in `src/db/supabase.ts` for these queries. Use this caching function (e.g. `getCachedSocials()`) in the shared component instead of querying Supabase directly.

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -1,92 +1,88 @@
 ---
 import Icon from "./base/Icon.astro";
-import { supabase, type Socials } from "@db/supabase";
+import { getCachedSocials, type Socials } from "@db/supabase";
 import Social from "./utilities/Social.astro";
 const today = new Date();
 
 interface Link {
-	name: string;
-	href: string;
-	off?: boolean;
+  name: string;
+  href: string;
+  off?: boolean;
 }
 
 const {
-	links = [
-		{ name: "About us", href: "/about" },
-		{ name: "Contact us", href: "/contact", off: true },
-		{ name: "Privacy policy", href: "/privacy" },
-	],
+  links = [
+    { name: "About us", href: "/about" },
+    { name: "Contact us", href: "/contact", off: true },
+    { name: "Privacy policy", href: "/privacy" },
+  ],
 } = Astro.props;
 
-const { data, error } = await supabase
-	.from("socials")
-	.select()
-	.returns<Socials[]>();
+const { data, error } = await getCachedSocials();
 ---
 
 <footer class="w-full h-full bg-neutral-100">
-	<div id="main-container" class="container px-6 pt-12 mx-auto">
-		<div
-			class="grid grid-cols-1 gap-4 text-center grid-rows-auto lg:grid-cols-4 lg:gap-6"
-		>
-			<div class="float-left col-span-2 pb-2 h-34">
-				<h4>Subscribe to our newsletter</h4>
-				<form>
-					<input
-						class="p-2 m-2 border border-blue-300 rounded-md shadow"
-						type="email"
-						required="true"
-					/>
-					<button
-						class="p-2 m-2 border border-blue-300 rounded-md shadow fill-blue-200 hover:border-blue-700 hover:drop-shadow-2xl"
-						>Subscribe</button
-					>
-				</form>
-			</div>
-			<div class="h-34 lg:col-span-2">
-				<div class="grid grid-cols-2 my-2 width-full auto-cols-max">
-					<div>
-						<div class="flex justify-evenly">
-
-							{data && data.length > 0 && data.map((soc: Socials) => <Social social={soc} />)}
-						</div>
-					</div>
-					<div>
-						<ul class="text-left">
-							{
-								links.map(
-									(link: Link) =>
-										!link.off && (
-											<li class="list-none">
-												<a
-													class="neutral-link"
-													href={link.href}
-												>
-													{link.name}
-												</a>
-											</li>
-										)
-								)
-							}
-						</ul>
-					</div>
-				</div>
-			</div>
-			<div class="h-16 p-3 text-sm text-gray-400 lg:col-span-4">
-				<p>
-					&copy; {today.getFullYear()}
-					<a href="https://mlread.me">ML Readme Blog Posts</a> by
-					<a href="https://jeremygf.com">Jeremy Georges-Filteau</a> is
-					licensed under
-					<a
-						class="text-xs"
-						href="https://creativecommons.org/licenses/by-nc-sa/4.0/?ref=chooser-v1"
-						target="_blank"
-						rel="license noopener noreferrer"
-						>CC BY-NC-SA 4.0
-					</a>
-				</p>
-			</div>
-		</div>
-	</div>
+  <div id="main-container" class="container px-6 pt-12 mx-auto">
+    <div
+      class="grid grid-cols-1 gap-4 text-center grid-rows-auto lg:grid-cols-4 lg:gap-6"
+    >
+      <div class="float-left col-span-2 pb-2 h-34">
+        <h4>Subscribe to our newsletter</h4>
+        <form>
+          <input
+            class="p-2 m-2 border border-blue-300 rounded-md shadow"
+            type="email"
+            required="true"
+          />
+          <button
+            class="p-2 m-2 border border-blue-300 rounded-md shadow fill-blue-200 hover:border-blue-700 hover:drop-shadow-2xl"
+            >Subscribe</button
+          >
+        </form>
+      </div>
+      <div class="h-34 lg:col-span-2">
+        <div class="grid grid-cols-2 my-2 width-full auto-cols-max">
+          <div>
+            <div class="flex justify-evenly">
+              {
+                data &&
+                  data.length > 0 &&
+                  data.map((soc: Socials) => <Social social={soc} />)
+              }
+            </div>
+          </div>
+          <div>
+            <ul class="text-left">
+              {
+                links.map(
+                  (link: Link) =>
+                    !link.off && (
+                      <li class="list-none">
+                        <a class="neutral-link" href={link.href}>
+                          {link.name}
+                        </a>
+                      </li>
+                    ),
+                )
+              }
+            </ul>
+          </div>
+        </div>
+      </div>
+      <div class="h-16 p-3 text-sm text-gray-400 lg:col-span-4">
+        <p>
+          &copy; {today.getFullYear()}
+          <a href="https://mlread.me">ML Readme Blog Posts</a> by
+          <a href="https://jeremygf.com">Jeremy Georges-Filteau</a> is licensed under
+          <a
+            class="text-xs"
+            href="https://creativecommons.org/licenses/by-nc-sa/4.0/?ref=chooser-v1"
+            target="_blank"
+            rel="license noopener noreferrer"
+            >CC BY-NC-SA 4.0
+          </a>
+        </p>
+      </div>
+    </div>
+  </div>
 </footer>

--- a/src/db/supabase.ts
+++ b/src/db/supabase.ts
@@ -1,4 +1,3 @@
-
 import { createClient } from "@supabase/supabase-js";
 
 const supabaseUrl = import.meta.env.SUPABASE_URL;
@@ -6,157 +5,207 @@ const supabaseKey = import.meta.env.SUPABASE_KEY;
 
 export const supabase = createClient(supabaseUrl, supabaseKey);
 
-export type Json = string | number | boolean | null | { [key: string]: Json | undefined } | Json[]
+// Cache implementation for SSR
+let cachedSocials: { data: Socials[] | null; error: any } | null = null;
+let lastFetchTime = 0;
+const CACHE_TTL_MS = 5 * 60 * 1000; // 5 minutes
+
+export const getCachedSocials = async () => {
+  const now = Date.now();
+  if (cachedSocials && now - lastFetchTime < CACHE_TTL_MS) {
+    return cachedSocials;
+  }
+
+  const { data, error } = await supabase
+    .from("socials")
+    .select()
+    .returns<Socials[]>();
+
+  if (!error) {
+    cachedSocials = { data, error };
+    lastFetchTime = now;
+  }
+
+  return { data, error };
+};
+
+export type Json =
+  | string
+  | number
+  | boolean
+  | null
+  | { [key: string]: Json | undefined }
+  | Json[];
 
 export type Database = {
-	public: {
-		Tables: {
-			categories: {
-				Row: {
-					children: number[] | null
-					created_at: string
-					description: string | null
-					id: number
-					name: string | null
-					top: boolean | null
-				}
-				Insert: {
-					children?: number[] | null
-					created_at?: string
-					description?: string | null
-					id?: number
-					name?: string | null
-					top?: boolean | null
-				}
-				Update: {
-					children?: number[] | null
-					created_at?: string
-					description?: string | null
-					id?: number
-					name?: string | null
-					top?: boolean | null
-				}
-				Relationships: []
-			}
-			socials: {
-				Row: {
-					color: string
-					created_at: string
-					id: number
-					name: string
-					profile: string | null
-					url: string | null
-				}
-				Insert: {
-					color: string
-					created_at?: string
-					id?: number
-					name: string
-					profile?: string | null
-					url?: string | null
-				}
-				Update: {
-					color?: string
-					created_at?: string
-					id?: number
-					name?: string
-					profile?: string | null
-					url?: string | null
-				}
-				Relationships: []
-			}
-		}
-		Views: {
-			[_ in never]: never
-		}
-		Functions: {
-			[_ in never]: never
-		}
-		Enums: {
-			[_ in never]: never
-		}
-		CompositeTypes: {
-			[_ in never]: never
-		}
-	}
-}
+  public: {
+    Tables: {
+      categories: {
+        Row: {
+          children: number[] | null;
+          created_at: string;
+          description: string | null;
+          id: number;
+          name: string | null;
+          top: boolean | null;
+        };
+        Insert: {
+          children?: number[] | null;
+          created_at?: string;
+          description?: string | null;
+          id?: number;
+          name?: string | null;
+          top?: boolean | null;
+        };
+        Update: {
+          children?: number[] | null;
+          created_at?: string;
+          description?: string | null;
+          id?: number;
+          name?: string | null;
+          top?: boolean | null;
+        };
+        Relationships: [];
+      };
+      socials: {
+        Row: {
+          color: string;
+          created_at: string;
+          id: number;
+          name: string;
+          profile: string | null;
+          url: string | null;
+        };
+        Insert: {
+          color: string;
+          created_at?: string;
+          id?: number;
+          name: string;
+          profile?: string | null;
+          url?: string | null;
+        };
+        Update: {
+          color?: string;
+          created_at?: string;
+          id?: number;
+          name?: string;
+          profile?: string | null;
+          url?: string | null;
+        };
+        Relationships: [];
+      };
+    };
+    Views: {
+      [_ in never]: never;
+    };
+    Functions: {
+      [_ in never]: never;
+    };
+    Enums: {
+      [_ in never]: never;
+    };
+    CompositeTypes: {
+      [_ in never]: never;
+    };
+  };
+};
 
-type PublicSchema = Database[Extract<keyof Database, 'public'>]
+type PublicSchema = Database[Extract<keyof Database, "public">];
 
 export type Tables<
-	PublicTableNameOrOptions extends keyof (PublicSchema['Tables'] & PublicSchema['Views']) | { schema: keyof Database },
-	TableName extends PublicTableNameOrOptions extends { schema: keyof Database }
-		? keyof (Database[PublicTableNameOrOptions['schema']]['Tables'] & Database[PublicTableNameOrOptions['schema']]['Views'])
-		: never = never
+  PublicTableNameOrOptions extends
+    | keyof (PublicSchema["Tables"] & PublicSchema["Views"])
+    | { schema: keyof Database },
+  TableName extends PublicTableNameOrOptions extends { schema: keyof Database }
+    ? keyof (Database[PublicTableNameOrOptions["schema"]]["Tables"] &
+        Database[PublicTableNameOrOptions["schema"]]["Views"])
+    : never = never,
 > = PublicTableNameOrOptions extends { schema: keyof Database }
-	? (Database[PublicTableNameOrOptions['schema']]['Tables'] & Database[PublicTableNameOrOptions['schema']]['Views'])[TableName] extends {
-			Row: infer R
-		}
-		? R
-		: never
-	: PublicTableNameOrOptions extends keyof (PublicSchema['Tables'] & PublicSchema['Views'])
-		? (PublicSchema['Tables'] & PublicSchema['Views'])[PublicTableNameOrOptions] extends {
-				Row: infer R
-			}
-			? R
-			: never
-		: never
+  ? (Database[PublicTableNameOrOptions["schema"]]["Tables"] &
+      Database[PublicTableNameOrOptions["schema"]]["Views"])[TableName] extends {
+      Row: infer R;
+    }
+    ? R
+    : never
+  : PublicTableNameOrOptions extends keyof (PublicSchema["Tables"] &
+        PublicSchema["Views"])
+    ? (PublicSchema["Tables"] &
+        PublicSchema["Views"])[PublicTableNameOrOptions] extends {
+        Row: infer R;
+      }
+      ? R
+      : never
+    : never;
 
 export type TablesInsert<
-	PublicTableNameOrOptions extends keyof PublicSchema['Tables'] | { schema: keyof Database },
-	TableName extends PublicTableNameOrOptions extends { schema: keyof Database } ? keyof Database[PublicTableNameOrOptions['schema']]['Tables'] : never = never
+  PublicTableNameOrOptions extends
+    | keyof PublicSchema["Tables"]
+    | { schema: keyof Database },
+  TableName extends PublicTableNameOrOptions extends { schema: keyof Database }
+    ? keyof Database[PublicTableNameOrOptions["schema"]]["Tables"]
+    : never = never,
 > = PublicTableNameOrOptions extends { schema: keyof Database }
-	? Database[PublicTableNameOrOptions['schema']]['Tables'][TableName] extends {
-			Insert: infer I
-		}
-		? I
-		: never
-	: PublicTableNameOrOptions extends keyof PublicSchema['Tables']
-		? PublicSchema['Tables'][PublicTableNameOrOptions] extends {
-				Insert: infer I
-			}
-			? I
-			: never
-		: never
+  ? Database[PublicTableNameOrOptions["schema"]]["Tables"][TableName] extends {
+      Insert: infer I;
+    }
+    ? I
+    : never
+  : PublicTableNameOrOptions extends keyof PublicSchema["Tables"]
+    ? PublicSchema["Tables"][PublicTableNameOrOptions] extends {
+        Insert: infer I;
+      }
+      ? I
+      : never
+    : never;
 
 export type TablesUpdate<
-	PublicTableNameOrOptions extends keyof PublicSchema['Tables'] | { schema: keyof Database },
-	TableName extends PublicTableNameOrOptions extends { schema: keyof Database } ? keyof Database[PublicTableNameOrOptions['schema']]['Tables'] : never = never
+  PublicTableNameOrOptions extends
+    | keyof PublicSchema["Tables"]
+    | { schema: keyof Database },
+  TableName extends PublicTableNameOrOptions extends { schema: keyof Database }
+    ? keyof Database[PublicTableNameOrOptions["schema"]]["Tables"]
+    : never = never,
 > = PublicTableNameOrOptions extends { schema: keyof Database }
-	? Database[PublicTableNameOrOptions['schema']]['Tables'][TableName] extends {
-			Update: infer U
-		}
-		? U
-		: never
-	: PublicTableNameOrOptions extends keyof PublicSchema['Tables']
-		? PublicSchema['Tables'][PublicTableNameOrOptions] extends {
-				Update: infer U
-			}
-			? U
-			: never
-		: never
+  ? Database[PublicTableNameOrOptions["schema"]]["Tables"][TableName] extends {
+      Update: infer U;
+    }
+    ? U
+    : never
+  : PublicTableNameOrOptions extends keyof PublicSchema["Tables"]
+    ? PublicSchema["Tables"][PublicTableNameOrOptions] extends {
+        Update: infer U;
+      }
+      ? U
+      : never
+    : never;
 
 export type Enums<
-	PublicEnumNameOrOptions extends keyof PublicSchema['Enums'] | { schema: keyof Database },
-	EnumName extends PublicEnumNameOrOptions extends { schema: keyof Database } ? keyof Database[PublicEnumNameOrOptions['schema']]['Enums'] : never = never
+  PublicEnumNameOrOptions extends
+    | keyof PublicSchema["Enums"]
+    | { schema: keyof Database },
+  EnumName extends PublicEnumNameOrOptions extends { schema: keyof Database }
+    ? keyof Database[PublicEnumNameOrOptions["schema"]]["Enums"]
+    : never = never,
 > = PublicEnumNameOrOptions extends { schema: keyof Database }
-	? Database[PublicEnumNameOrOptions['schema']]['Enums'][EnumName]
-	: PublicEnumNameOrOptions extends keyof PublicSchema['Enums']
-		? PublicSchema['Enums'][PublicEnumNameOrOptions]
-		: never
+  ? Database[PublicEnumNameOrOptions["schema"]]["Enums"][EnumName]
+  : PublicEnumNameOrOptions extends keyof PublicSchema["Enums"]
+    ? PublicSchema["Enums"][PublicEnumNameOrOptions]
+    : never;
 
 export type CompositeTypes<
-	PublicCompositeTypeNameOrOptions extends keyof PublicSchema['CompositeTypes'] | { schema: keyof Database },
-	CompositeTypeName extends PublicCompositeTypeNameOrOptions extends {
-		schema: keyof Database
-	}
-		? keyof Database[PublicCompositeTypeNameOrOptions['schema']]['CompositeTypes']
-		: never = never
+  PublicCompositeTypeNameOrOptions extends
+    | keyof PublicSchema["CompositeTypes"]
+    | { schema: keyof Database },
+  CompositeTypeName extends PublicCompositeTypeNameOrOptions extends {
+    schema: keyof Database;
+  }
+    ? keyof Database[PublicCompositeTypeNameOrOptions["schema"]]["CompositeTypes"]
+    : never = never,
 > = PublicCompositeTypeNameOrOptions extends { schema: keyof Database }
-	? Database[PublicCompositeTypeNameOrOptions['schema']]['CompositeTypes'][CompositeTypeName]
-	: PublicCompositeTypeNameOrOptions extends keyof PublicSchema['CompositeTypes']
-		? PublicSchema['CompositeTypes'][PublicCompositeTypeNameOrOptions]
-		: never
+  ? Database[PublicCompositeTypeNameOrOptions["schema"]]["CompositeTypes"][CompositeTypeName]
+  : PublicCompositeTypeNameOrOptions extends keyof PublicSchema["CompositeTypes"]
+    ? PublicSchema["CompositeTypes"][PublicCompositeTypeNameOrOptions]
+    : never;
 
-export type Categories = Tables<'categories'>
-export type Socials = Tables<'socials'>
+export type Categories = Tables<"categories">;
+export type Socials = Tables<"socials">;

--- a/tests/main.spec.ts
+++ b/tests/main.spec.ts
@@ -3,7 +3,7 @@ const TARGET_URL = process.env.TARGET_URL || 'http://localhost:3000'
 
 test('test', async ({ page }) => {
 	await page.goto(TARGET_URL)
-	await expect(page.getByRole('link', { name: 'ML Readme' })).toBeVisible()
+	await expect(page.getByRole('link', { name: 'ML Readme', exact: true })).toBeVisible()
 	await expect(page.getByRole('link', { name: 'Home' })).toBeVisible()
 	//await expect(page.getByRole('link', { name: 'Blog' })).toBeVisible();
 	await expect(page.getByRole('link', { name: 'About', exact: true })).toBeVisible()


### PR DESCRIPTION
💡 **What**: Added an in-memory caching layer `getCachedSocials` with a 5-minute TTL in `src/db/supabase.ts` for the `socials` table query. Replaced the direct Supabase fetch call in `src/components/Footer.astro` with this new cached function.

🎯 **Why**: Shared components like `Footer.astro` exist on pages with `prerender = false` (Server-Side Rendered pages, like the `index.astro` home page). Because Astro SSR executes the script on every request, this resulted in redundant Supabase database hits for relatively static data (social links), acting as a massive architectural bottleneck causing latency and excessive DB load.

📊 **Impact**: This drastically reduces the number of database queries executed per SSR page request. Social links data is cached in memory across requests for 5 minutes, significantly speeding up time-to-first-byte (TTFB) and reducing Supabase bandwidth and API calls. 

🔬 **Measurement**: Verify by running `bun run dev` and observing network requests or Supabase query logs. The DB should only be queried once every 5 minutes rather than on every single page load of an SSR route.

---
*PR created automatically by Jules for task [15360605926330888472](https://jules.google.com/task/15360605926330888472) started by @jgeofil*