### PR TITLE
🛡️ Sentinel: [HIGH] Fix XSS vulnerability in HLine component

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-03-18 - Prevent XSS in HLine Component
+**Vulnerability:** The `HLine.astro` component uses `set:html` with dynamic string interpolation (`tagline`) which could allow Cross-Site Scripting (XSS) if the `tagline` prop contains malicious user input.
+**Learning:** Using `set:html` with unescaped variables bypasses Astro's built-in XSS protections. Even for internal components, defense in depth dictates that we shouldn't trust props to be safe.
+**Prevention:** Avoid `set:html` for dynamic content styling. Use standard Astro JSX for structure and conditional classes (e.g., `<span class={...}>{tagline}</span>`) which automatically escapes the text content.

--- a/src/components/base/HLine.astro
+++ b/src/components/base/HLine.astro
@@ -1,11 +1,9 @@
 ---
-const { tagline = 'Section 1', center = 'c' } = Astro.props
-
-const text = `<span class="px-5 pr-6 ${center == 'c' ? 'shrink-0' : ''}">${tagline}</span>`
+const { tagline = "Section 1", center = "c" } = Astro.props;
 ---
 
 <span class="flex items-center">
-	{center == 'r' || center == 'c' ? <span class="h-px flex-1 bg-black" /> : ''}
-	<span set:html={text} />
-	{center == 'l' || center == 'c' ? <span class="h-px flex-1 bg-black" /> : ''}
+  {center == "r" || center == "c" ? <span class="h-px flex-1 bg-black" /> : ""}
+  <span class={`px-5 pr-6 ${center == "c" ? "shrink-0" : ""}`}>{tagline}</span>
+  {center == "l" || center == "c" ? <span class="h-px flex-1 bg-black" /> : ""}
 </span>

--- a/tests/main.spec.ts
+++ b/tests/main.spec.ts
@@ -3,7 +3,7 @@ const TARGET_URL = process.env.TARGET_URL || 'http://localhost:3000'
 
 test('test', async ({ page }) => {
 	await page.goto(TARGET_URL)
-	await expect(page.getByRole('link', { name: 'ML Readme' })).toBeVisible()
+	await expect(page.getByRole('link', { name: 'ML Readme', exact: true })).toBeVisible()
 	await expect(page.getByRole('link', { name: 'Home' })).toBeVisible()
 	//await expect(page.getByRole('link', { name: 'Blog' })).toBeVisible();
 	await expect(page.getByRole('link', { name: 'About', exact: true })).toBeVisible()


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The `HLine.astro` component was using `set:html` with unsanitized string interpolation to render text content, creating an XSS vulnerability.
🎯 Impact: This could allow Cross-Site Scripting (XSS) via maliciously constructed properties.
🔧 Fix: Replaced `set:html` with standard Astro JSX string interpolation (`<span class={...}>{tagline}</span>`), which naturally escapes the content. Fixed strict mode locators in main test to make tests pass reliably.
✅ Verification: Ran `bun run lint` and `bun run test` locally. Confirmed `package-lock.json` and `package.json` unmodified. Added a learning to the Sentinel journal.

---
*PR created automatically by Jules for task [16589712722674256718](https://jules.google.com/task/16589712722674256718) started by @jgeofil*