### PR TITLE
⚡ Bolt: [performance improvement] Implement in-memory caching for Supabase SSR queries

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-03-18 - SSR Subcomponents Trigger Redundant Database Queries
+**Learning:** In Astro, when a page has `export const prerender = false` (making it SSR), all of its components are evaluated on every request. If a shared component (like a Footer or Header) makes direct database queries (e.g., Supabase `.from()`), this results in redundant database calls for every page load, creating a severe performance bottleneck.
+**Action:** Always implement an in-memory caching layer with a TTL (e.g., in `src/db/supabase.ts`) for queries used by shared components on SSR pages to mitigate unnecessary database load and improve response times.

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -1,6 +1,6 @@
 ---
 import Icon from "./base/Icon.astro";
-import { supabase, type Socials } from "@db/supabase";
+import { getCachedSocials, type Socials } from "@db/supabase";
 import Social from "./utilities/Social.astro";
 const today = new Date();
 
@@ -18,10 +18,7 @@ const {
 	],
 } = Astro.props;
 
-const { data, error } = await supabase
-	.from("socials")
-	.select()
-	.returns<Socials[]>();
+const { data, error } = await getCachedSocials();
 ---
 
 <footer class="w-full h-full bg-neutral-100">

--- a/src/db/supabase.ts
+++ b/src/db/supabase.ts
@@ -6,6 +6,28 @@ const supabaseKey = import.meta.env.SUPABASE_KEY;
 
 export const supabase = createClient(supabaseUrl, supabaseKey);
 
+// In-memory cache for SSR pages to prevent redundant Supabase calls
+// This is critical because SSR pages like index.astro run shared components (like Footer.astro)
+// on every request, executing the same queries over and over again.
+const queryCache = new Map<string, { data: any; error: any; timestamp: number }>();
+const CACHE_TTL_MS = 60 * 1000; // 60 seconds
+
+export async function getCachedSocials(): Promise<{ data: Socials[] | null; error: any }> {
+	const cacheKey = "socials_all";
+	const now = Date.now();
+
+	const cached = queryCache.get(cacheKey);
+	if (cached && (now - cached.timestamp < CACHE_TTL_MS)) {
+		return { data: cached.data, error: cached.error };
+	}
+
+	const { data, error } = await supabase.from("socials").select().returns<Socials[]>();
+
+	queryCache.set(cacheKey, { data, error, timestamp: now });
+
+	return { data, error };
+}
+
 export type Json = string | number | boolean | null | { [key: string]: Json | undefined } | Json[]
 
 export type Database = {

--- a/tests/main.spec.ts
+++ b/tests/main.spec.ts
@@ -3,7 +3,7 @@ const TARGET_URL = process.env.TARGET_URL || 'http://localhost:3000'
 
 test('test', async ({ page }) => {
 	await page.goto(TARGET_URL)
-	await expect(page.getByRole('link', { name: 'ML Readme' })).toBeVisible()
+	await expect(page.getByRole('link', { name: 'ML Readme', exact: true })).toBeVisible()
 	await expect(page.getByRole('link', { name: 'Home' })).toBeVisible()
 	//await expect(page.getByRole('link', { name: 'Blog' })).toBeVisible();
 	await expect(page.getByRole('link', { name: 'About', exact: true })).toBeVisible()


### PR DESCRIPTION
💡 **What:** 
Implemented a 60-second TTL in-memory cache for the Supabase `socials` query in `src/db/supabase.ts` and updated `src/components/Footer.astro` to use it. Documented this codebase-specific performance pattern in a new `.jules/bolt.md` journal entry. Also fixed a strict-mode violation in `tests/main.spec.ts` caused by multiple matching "ML Readme" links on the page.

🎯 **Why:** 
The app utilizes SSR for certain pages (e.g., `index.astro` sets `export const prerender = false`). Shared components like the Footer are evaluated on every request for these SSR pages. Without caching, the raw `supabase.from('socials').select()` call in `Footer.astro` causes a redundant database request for every single page load, creating a severe performance bottleneck.

📊 **Impact:** 
Eliminates redundant Supabase network and database calls for the `socials` query during SSR page loads, reducing response times and preventing unnecessary database load.

🔬 **Measurement:** 
1. Run `bun run dev` and navigate between pages (or refresh SSR pages like `/`).
2. Observe network traffic or Supabase database logs; the `socials` query will only execute once every 60 seconds across all SSR requests.

---
*PR created automatically by Jules for task [15755259545211716964](https://jules.google.com/task/15755259545211716964) started by @jgeofil*