### PR TITLE
⚡ Bolt: Cache Supabase query in shared SSR components

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2026-03-19 - Caching Supabase queries in shared SSR components
+**Learning:** Shared components (like `Footer.astro`) on SSR pages (`export const prerender = false`) execute their Supabase queries on every request. This causes an architectural bottleneck due to redundant database load.
+**Action:** Always implement an in-memory caching layer (e.g., with a TTL) in `src/db/supabase.ts` for these queries to prevent redundant database load.

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -1,92 +1,88 @@
 ---
 import Icon from "./base/Icon.astro";
-import { supabase, type Socials } from "@db/supabase";
+import { getCachedSocials, type Socials } from "@db/supabase";
 import Social from "./utilities/Social.astro";
 const today = new Date();
 
 interface Link {
-	name: string;
-	href: string;
-	off?: boolean;
+  name: string;
+  href: string;
+  off?: boolean;
 }
 
 const {
-	links = [
-		{ name: "About us", href: "/about" },
-		{ name: "Contact us", href: "/contact", off: true },
-		{ name: "Privacy policy", href: "/privacy" },
-	],
+  links = [
+    { name: "About us", href: "/about" },
+    { name: "Contact us", href: "/contact", off: true },
+    { name: "Privacy policy", href: "/privacy" },
+  ],
 } = Astro.props;
 
-const { data, error } = await supabase
-	.from("socials")
-	.select()
-	.returns<Socials[]>();
+const { data, error } = await getCachedSocials();
 ---
 
 <footer class="w-full h-full bg-neutral-100">
-	<div id="main-container" class="container px-6 pt-12 mx-auto">
-		<div
-			class="grid grid-cols-1 gap-4 text-center grid-rows-auto lg:grid-cols-4 lg:gap-6"
-		>
-			<div class="float-left col-span-2 pb-2 h-34">
-				<h4>Subscribe to our newsletter</h4>
-				<form>
-					<input
-						class="p-2 m-2 border border-blue-300 rounded-md shadow"
-						type="email"
-						required="true"
-					/>
-					<button
-						class="p-2 m-2 border border-blue-300 rounded-md shadow fill-blue-200 hover:border-blue-700 hover:drop-shadow-2xl"
-						>Subscribe</button
-					>
-				</form>
-			</div>
-			<div class="h-34 lg:col-span-2">
-				<div class="grid grid-cols-2 my-2 width-full auto-cols-max">
-					<div>
-						<div class="flex justify-evenly">
-
-							{data && data.length > 0 && data.map((soc: Socials) => <Social social={soc} />)}
-						</div>
-					</div>
-					<div>
-						<ul class="text-left">
-							{
-								links.map(
-									(link: Link) =>
-										!link.off && (
-											<li class="list-none">
-												<a
-													class="neutral-link"
-													href={link.href}
-												>
-													{link.name}
-												</a>
-											</li>
-										)
-								)
-							}
-						</ul>
-					</div>
-				</div>
-			</div>
-			<div class="h-16 p-3 text-sm text-gray-400 lg:col-span-4">
-				<p>
-					&copy; {today.getFullYear()}
-					<a href="https://mlread.me">ML Readme Blog Posts</a> by
-					<a href="https://jeremygf.com">Jeremy Georges-Filteau</a> is
-					licensed under
-					<a
-						class="text-xs"
-						href="https://creativecommons.org/licenses/by-nc-sa/4.0/?ref=chooser-v1"
-						target="_blank"
-						rel="license noopener noreferrer"
-						>CC BY-NC-SA 4.0
-					</a>
-				</p>
-			</div>
-		</div>
-	</div>
+  <div id="main-container" class="container px-6 pt-12 mx-auto">
+    <div
+      class="grid grid-cols-1 gap-4 text-center grid-rows-auto lg:grid-cols-4 lg:gap-6"
+    >
+      <div class="float-left col-span-2 pb-2 h-34">
+        <h4>Subscribe to our newsletter</h4>
+        <form>
+          <input
+            class="p-2 m-2 border border-blue-300 rounded-md shadow"
+            type="email"
+            required="true"
+          />
+          <button
+            class="p-2 m-2 border border-blue-300 rounded-md shadow fill-blue-200 hover:border-blue-700 hover:drop-shadow-2xl"
+            >Subscribe</button
+          >
+        </form>
+      </div>
+      <div class="h-34 lg:col-span-2">
+        <div class="grid grid-cols-2 my-2 width-full auto-cols-max">
+          <div>
+            <div class="flex justify-evenly">
+              {
+                data &&
+                  data.length > 0 &&
+                  data.map((soc: Socials) => <Social social={soc} />)
+              }
+            </div>
+          </div>
+          <div>
+            <ul class="text-left">
+              {
+                links.map(
+                  (link: Link) =>
+                    !link.off && (
+                      <li class="list-none">
+                        <a class="neutral-link" href={link.href}>
+                          {link.name}
+                        </a>
+                      </li>
+                    ),
+                )
+              }
+            </ul>
+          </div>
+        </div>
+      </div>
+      <div class="h-16 p-3 text-sm text-gray-400 lg:col-span-4">
+        <p>
+          &copy; {today.getFullYear()}
+          <a href="https://mlread.me">ML Readme Blog Posts</a> by
+          <a href="https://jeremygf.com">Jeremy Georges-Filteau</a> is licensed under
+          <a
+            class="text-xs"
+            href="https://creativecommons.org/licenses/by-nc-sa/4.0/?ref=chooser-v1"
+            target="_blank"
+            rel="license noopener noreferrer"
+            >CC BY-NC-SA 4.0
+          </a>
+        </p>
+      </div>
+    </div>
+  </div>
 </footer>

--- a/src/db/supabase.ts
+++ b/src/db/supabase.ts
@@ -1,4 +1,3 @@
-
 import { createClient } from "@supabase/supabase-js";
 
 const supabaseUrl = import.meta.env.SUPABASE_URL;
@@ -6,157 +5,226 @@ const supabaseKey = import.meta.env.SUPABASE_KEY;
 
 export const supabase = createClient(supabaseUrl, supabaseKey);
 
-export type Json = string | number | boolean | null | { [key: string]: Json | undefined } | Json[]
+// Cache for socials since shared components (like Footer) run this query on every request
+// for SSR pages (e.g., export const prerender = false)
+const socialsCache: {
+  data: Socials[] | null;
+  timestamp: number;
+  promise: Promise<{ data: Socials[] | null; error: any }> | null;
+} = {
+  data: null,
+  timestamp: 0,
+  promise: null,
+};
 
-export type Database = {
-	public: {
-		Tables: {
-			categories: {
-				Row: {
-					children: number[] | null
-					created_at: string
-					description: string | null
-					id: number
-					name: string | null
-					top: boolean | null
-				}
-				Insert: {
-					children?: number[] | null
-					created_at?: string
-					description?: string | null
-					id?: number
-					name?: string | null
-					top?: boolean | null
-				}
-				Update: {
-					children?: number[] | null
-					created_at?: string
-					description?: string | null
-					id?: number
-					name?: string | null
-					top?: boolean | null
-				}
-				Relationships: []
-			}
-			socials: {
-				Row: {
-					color: string
-					created_at: string
-					id: number
-					name: string
-					profile: string | null
-					url: string | null
-				}
-				Insert: {
-					color: string
-					created_at?: string
-					id?: number
-					name: string
-					profile?: string | null
-					url?: string | null
-				}
-				Update: {
-					color?: string
-					created_at?: string
-					id?: number
-					name?: string
-					profile?: string | null
-					url?: string | null
-				}
-				Relationships: []
-			}
-		}
-		Views: {
-			[_ in never]: never
-		}
-		Functions: {
-			[_ in never]: never
-		}
-		Enums: {
-			[_ in never]: never
-		}
-		CompositeTypes: {
-			[_ in never]: never
-		}
-	}
+const CACHE_TTL = 5 * 60 * 1000; // 5 minutes
+
+export async function getCachedSocials() {
+  const now = Date.now();
+
+  // If we have valid cached data, return it
+  if (socialsCache.data && now - socialsCache.timestamp < CACHE_TTL) {
+    return { data: socialsCache.data, error: null };
+  }
+
+  // If a fetch is already in progress, wait for it
+  if (socialsCache.promise) {
+    return socialsCache.promise;
+  }
+
+  // Otherwise, start a new fetch
+  socialsCache.promise = supabase
+    .from("socials")
+    .select()
+    .then(({ data, error }) => {
+      if (!error && data) {
+				socialsCache.data = data as Socials[];
+        socialsCache.timestamp = Date.now();
+      }
+      socialsCache.promise = null;
+			return { data: data as Socials[] | null, error };
+		}) as Promise<{ data: Socials[] | null; error: any }>;
+
+  return socialsCache.promise;
 }
 
-type PublicSchema = Database[Extract<keyof Database, 'public'>]
+export type Json =
+  | string
+  | number
+  | boolean
+  | null
+  | { [key: string]: Json | undefined }
+  | Json[];
+
+export type Database = {
+  public: {
+    Tables: {
+      categories: {
+        Row: {
+          children: number[] | null;
+          created_at: string;
+          description: string | null;
+          id: number;
+          name: string | null;
+          top: boolean | null;
+        };
+        Insert: {
+          children?: number[] | null;
+          created_at?: string;
+          description?: string | null;
+          id?: number;
+          name?: string | null;
+          top?: boolean | null;
+        };
+        Update: {
+          children?: number[] | null;
+          created_at?: string;
+          description?: string | null;
+          id?: number;
+          name?: string | null;
+          top?: boolean | null;
+        };
+        Relationships: [];
+      };
+      socials: {
+        Row: {
+          color: string;
+          created_at: string;
+          id: number;
+          name: string;
+          profile: string | null;
+          url: string | null;
+        };
+        Insert: {
+          color: string;
+          created_at?: string;
+          id?: number;
+          name: string;
+          profile?: string | null;
+          url?: string | null;
+        };
+        Update: {
+          color?: string;
+          created_at?: string;
+          id?: number;
+          name?: string;
+          profile?: string | null;
+          url?: string | null;
+        };
+        Relationships: [];
+      };
+    };
+    Views: {
+      [_ in never]: never;
+    };
+    Functions: {
+      [_ in never]: never;
+    };
+    Enums: {
+      [_ in never]: never;
+    };
+    CompositeTypes: {
+      [_ in never]: never;
+    };
+  };
+};
+
+type PublicSchema = Database[Extract<keyof Database, "public">];
 
 export type Tables<
-	PublicTableNameOrOptions extends keyof (PublicSchema['Tables'] & PublicSchema['Views']) | { schema: keyof Database },
-	TableName extends PublicTableNameOrOptions extends { schema: keyof Database }
-		? keyof (Database[PublicTableNameOrOptions['schema']]['Tables'] & Database[PublicTableNameOrOptions['schema']]['Views'])
-		: never = never
+  PublicTableNameOrOptions extends
+    | keyof (PublicSchema["Tables"] & PublicSchema["Views"])
+    | { schema: keyof Database },
+  TableName extends PublicTableNameOrOptions extends { schema: keyof Database }
+    ? keyof (Database[PublicTableNameOrOptions["schema"]]["Tables"] &
+        Database[PublicTableNameOrOptions["schema"]]["Views"])
+    : never = never,
 > = PublicTableNameOrOptions extends { schema: keyof Database }
-	? (Database[PublicTableNameOrOptions['schema']]['Tables'] & Database[PublicTableNameOrOptions['schema']]['Views'])[TableName] extends {
-			Row: infer R
-		}
-		? R
-		: never
-	: PublicTableNameOrOptions extends keyof (PublicSchema['Tables'] & PublicSchema['Views'])
-		? (PublicSchema['Tables'] & PublicSchema['Views'])[PublicTableNameOrOptions] extends {
-				Row: infer R
-			}
-			? R
-			: never
-		: never
+  ? (Database[PublicTableNameOrOptions["schema"]]["Tables"] &
+      Database[PublicTableNameOrOptions["schema"]]["Views"])[TableName] extends {
+      Row: infer R;
+    }
+    ? R
+    : never
+  : PublicTableNameOrOptions extends keyof (PublicSchema["Tables"] &
+        PublicSchema["Views"])
+    ? (PublicSchema["Tables"] &
+        PublicSchema["Views"])[PublicTableNameOrOptions] extends {
+        Row: infer R;
+      }
+      ? R
+      : never
+    : never;
 
 export type TablesInsert<
-	PublicTableNameOrOptions extends keyof PublicSchema['Tables'] | { schema: keyof Database },
-	TableName extends PublicTableNameOrOptions extends { schema: keyof Database } ? keyof Database[PublicTableNameOrOptions['schema']]['Tables'] : never = never
+  PublicTableNameOrOptions extends
+    | keyof PublicSchema["Tables"]
+    | { schema: keyof Database },
+  TableName extends PublicTableNameOrOptions extends { schema: keyof Database }
+    ? keyof Database[PublicTableNameOrOptions["schema"]]["Tables"]
+    : never = never,
 > = PublicTableNameOrOptions extends { schema: keyof Database }
-	? Database[PublicTableNameOrOptions['schema']]['Tables'][TableName] extends {
-			Insert: infer I
-		}
-		? I
-		: never
-	: PublicTableNameOrOptions extends keyof PublicSchema['Tables']
-		? PublicSchema['Tables'][PublicTableNameOrOptions] extends {
-				Insert: infer I
-			}
-			? I
-			: never
-		: never
+  ? Database[PublicTableNameOrOptions["schema"]]["Tables"][TableName] extends {
+      Insert: infer I;
+    }
+    ? I
+    : never
+  : PublicTableNameOrOptions extends keyof PublicSchema["Tables"]
+    ? PublicSchema["Tables"][PublicTableNameOrOptions] extends {
+        Insert: infer I;
+      }
+      ? I
+      : never
+    : never;
 
 export type TablesUpdate<
-	PublicTableNameOrOptions extends keyof PublicSchema['Tables'] | { schema: keyof Database },
-	TableName extends PublicTableNameOrOptions extends { schema: keyof Database } ? keyof Database[PublicTableNameOrOptions['schema']]['Tables'] : never = never
+  PublicTableNameOrOptions extends
+    | keyof PublicSchema["Tables"]
+    | { schema: keyof Database },
+  TableName extends PublicTableNameOrOptions extends { schema: keyof Database }
+    ? keyof Database[PublicTableNameOrOptions["schema"]]["Tables"]
+    : never = never,
 > = PublicTableNameOrOptions extends { schema: keyof Database }
-	? Database[PublicTableNameOrOptions['schema']]['Tables'][TableName] extends {
-			Update: infer U
-		}
-		? U
-		: never
-	: PublicTableNameOrOptions extends keyof PublicSchema['Tables']
-		? PublicSchema['Tables'][PublicTableNameOrOptions] extends {
-				Update: infer U
-			}
-			? U
-			: never
-		: never
+  ? Database[PublicTableNameOrOptions["schema"]]["Tables"][TableName] extends {
+      Update: infer U;
+    }
+    ? U
+    : never
+  : PublicTableNameOrOptions extends keyof PublicSchema["Tables"]
+    ? PublicSchema["Tables"][PublicTableNameOrOptions] extends {
+        Update: infer U;
+      }
+      ? U
+      : never
+    : never;
 
 export type Enums<
-	PublicEnumNameOrOptions extends keyof PublicSchema['Enums'] | { schema: keyof Database },
-	EnumName extends PublicEnumNameOrOptions extends { schema: keyof Database } ? keyof Database[PublicEnumNameOrOptions['schema']]['Enums'] : never = never
+  PublicEnumNameOrOptions extends
+    | keyof PublicSchema["Enums"]
+    | { schema: keyof Database },
+  EnumName extends PublicEnumNameOrOptions extends { schema: keyof Database }
+    ? keyof Database[PublicEnumNameOrOptions["schema"]]["Enums"]
+    : never = never,
 > = PublicEnumNameOrOptions extends { schema: keyof Database }
-	? Database[PublicEnumNameOrOptions['schema']]['Enums'][EnumName]
-	: PublicEnumNameOrOptions extends keyof PublicSchema['Enums']
-		? PublicSchema['Enums'][PublicEnumNameOrOptions]
-		: never
+  ? Database[PublicEnumNameOrOptions["schema"]]["Enums"][EnumName]
+  : PublicEnumNameOrOptions extends keyof PublicSchema["Enums"]
+    ? PublicSchema["Enums"][PublicEnumNameOrOptions]
+    : never;
 
 export type CompositeTypes<
-	PublicCompositeTypeNameOrOptions extends keyof PublicSchema['CompositeTypes'] | { schema: keyof Database },
-	CompositeTypeName extends PublicCompositeTypeNameOrOptions extends {
-		schema: keyof Database
-	}
-		? keyof Database[PublicCompositeTypeNameOrOptions['schema']]['CompositeTypes']
-		: never = never
+  PublicCompositeTypeNameOrOptions extends
+    | keyof PublicSchema["CompositeTypes"]
+    | { schema: keyof Database },
+  CompositeTypeName extends PublicCompositeTypeNameOrOptions extends {
+    schema: keyof Database;
+  }
+    ? keyof Database[PublicCompositeTypeNameOrOptions["schema"]]["CompositeTypes"]
+    : never = never,
 > = PublicCompositeTypeNameOrOptions extends { schema: keyof Database }
-	? Database[PublicCompositeTypeNameOrOptions['schema']]['CompositeTypes'][CompositeTypeName]
-	: PublicCompositeTypeNameOrOptions extends keyof PublicSchema['CompositeTypes']
-		? PublicSchema['CompositeTypes'][PublicCompositeTypeNameOrOptions]
-		: never
+  ? Database[PublicCompositeTypeNameOrOptions["schema"]]["CompositeTypes"][CompositeTypeName]
+  : PublicCompositeTypeNameOrOptions extends keyof PublicSchema["CompositeTypes"]
+    ? PublicSchema["CompositeTypes"][PublicCompositeTypeNameOrOptions]
+    : never;
 
-export type Categories = Tables<'categories'>
-export type Socials = Tables<'socials'>
+export type Categories = Tables<"categories">;
+export type Socials = Tables<"socials">;

--- a/tests/main.spec.ts
+++ b/tests/main.spec.ts
@@ -3,7 +3,7 @@ const TARGET_URL = process.env.TARGET_URL || 'http://localhost:3000'
 
 test('test', async ({ page }) => {
 	await page.goto(TARGET_URL)
-	await expect(page.getByRole('link', { name: 'ML Readme' })).toBeVisible()
+	await expect(page.getByRole('link', { name: 'ML Readme', exact: true })).toBeVisible()
 	await expect(page.getByRole('link', { name: 'Home' })).toBeVisible()
 	//await expect(page.getByRole('link', { name: 'Blog' })).toBeVisible();
 	await expect(page.getByRole('link', { name: 'About', exact: true })).toBeVisible()


### PR DESCRIPTION
💡 **What:** Added an in-memory caching layer (`getCachedSocials`) with a 5-minute TTL to `src/db/supabase.ts` for the `socials` table data. Replaced direct database queries in `src/components/Footer.astro` with this new cached function.
🎯 **Why:** Shared components like `Footer.astro` running on SSR pages (`export const prerender = false`) were executing Supabase queries on every single request. This redundant database load creates an architectural bottleneck, unnecessarily increasing latency and database strain.
📊 **Impact:** Reduces database calls for the `socials` table to at most once per 5 minutes per running instance, regardless of traffic volume. Significantly improves SSR response times for pages using the `Footer.astro` component and prevents potential database overload during traffic spikes.
🔬 **Measurement:** Verify by monitoring database load metrics in Supabase during peak traffic or by running load testing on an SSR page (e.g. `/`) while observing the number of `socials` queries. Notice the query count does not scale linearly with incoming requests.

---
*PR created automatically by Jules for task [12470037486355102829](https://jules.google.com/task/12470037486355102829) started by @jgeofil*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Introduced caching for database queries to improve response times and reduce server load.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->