### PR TITLE
⚡ Bolt: Eager load above-the-fold PostCard images for faster LCP

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -7,3 +7,7 @@
 ## 2024-05-23 - [Date Formatting Bottleneck]
 **Learning:** `Date.toLocaleDateString` is shockingly slow when called repeatedly (e.g., rendering a list of blog posts) because it instantiates a new `Intl.DateTimeFormat` object each time. A benchmark showed unoptimized taking ~730ms vs optimized taking ~2ms for 1000 dates.
 **Action:** When formatting multiple dates, cache the `Intl.DateTimeFormat` instance globally and reuse its `.format(date)` method instead of calling `.toLocaleDateString()` directly on the Date instances.
+
+## 2026-03-26 - Adding Eager Loading to Above-The-Fold Images
+**Learning:** Astro's `Image` component natively supports `loading="eager"` and `fetchpriority="high"`, but this is frequently forgotten on main entry points and list elements like article cards or the top image in a list. When images represent Largest Contentful Paint (LCP) and are displayed immediately, failing to add these attributes can have a big impact on LCP scores.
+**Action:** Always check components containing `Image` elements, particularly hero banners, avatars, or lists of cards, to see if they can benefit from `loading="eager"` and `fetchpriority="high"` for the initial/first items to improve the critical rendering path.

--- a/src/components/utilities/PostCard.astro
+++ b/src/components/utilities/PostCard.astro
@@ -1,41 +1,55 @@
 ---
-import { getEntries, getEntry } from 'astro:content'
-import { formatDate } from '@utils/format'
-import Avatar from '@components/base/Avatar.astro'
-import Tag from '@components/base/Tag.astro'
-import { Image } from 'astro:assets'
+import { getEntries, getEntry } from "astro:content";
+import { formatDate } from "@utils/format";
+import Avatar from "@components/base/Avatar.astro";
+import Tag from "@components/base/Tag.astro";
+import { Image } from "astro:assets";
 
-const { id, data } = Astro.props
+const { id, data, eager = false } = Astro.props;
 
-const postTags = await getEntries<'tags'>(data.tags)
-const section = await getEntry('sections', data.sections.id)
+const postTags = await getEntries<"tags">(data.tags);
+const section = await getEntry("sections", data.sections.id);
 ---
 
 <div class="max-w-2xl overflow-hidden rounded-lg bg-white shadow-md">
-	<Image class="h-64 w-full object-cover" src={data.cover.src} alt={data.cover.alt} />
+  {
+    /* ⚡ Bolt Optimization: Eager load PostCard image when it's above the fold for faster LCP */
+  }
+  <Image
+    class="h-64 w-full object-cover"
+    src={data.cover.src}
+    alt={data.cover.alt}
+    loading={eager ? "eager" : "lazy"}
+    fetchpriority={eager ? "high" : "auto"}
+  />
 
-	<div class="p-6">
-		<div>
-			<a href=`/sections/${section.id}`>
-				<span class="text-xs font-light uppercase text-blue-600">{section.data.name}</span>
-			</a>
-			<a
-				href={`/blog/${id}/`}
-				class:list={['mt-2 block text-xl font-semibold text-gray-800 transition-colors', 'transform duration-300 hover:text-gray-600 hover:underline']}
-				tabindex="0"
-				role="link">{data.title}</a
-			>
-			<p class="mt-2 text-sm text-gray-600 dark:text-gray-400">
-				{data.description}
-			</p>
-			<div class="pb-2">
-				{postTags.map((tag) => <Tag class={tag.data.color} {...tag.data} />)}
-			</div>
-		</div>
-		<div class="mt-4">
-			<div class="float-right mx-2 mb-4 inline-block text-xs text-gray-600">
-				{formatDate(data.pubDate)}
-			</div>
-		</div>
-	</div>
+  <div class="p-6">
+    <div>
+      <a href=`/sections/${section.id}`>
+        <span class="text-xs font-light uppercase text-blue-600"
+          >{section.data.name}</span
+        >
+      </a>
+      <a
+        href={`/blog/${id}/`}
+        class:list={[
+          "mt-2 block text-xl font-semibold text-gray-800 transition-colors",
+          "transform duration-300 hover:text-gray-600 hover:underline",
+        ]}
+        tabindex="0"
+        role="link">{data.title}</a
+      >
+      <p class="mt-2 text-sm text-gray-600 dark:text-gray-400">
+        {data.description}
+      </p>
+      <div class="pb-2">
+        {postTags.map((tag) => <Tag class={tag.data.color} {...tag.data} />)}
+      </div>
+    </div>
+    <div class="mt-4">
+      <div class="float-right mx-2 mb-4 inline-block text-xs text-gray-600">
+        {formatDate(data.pubDate)}
+      </div>
+    </div>
+  </div>
 </div>

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -1,13 +1,15 @@
 ---
-import PostCard from '@components/utilities/PostCard.astro'
-import General from '@layouts/General.astro'
-import { getCollection } from 'astro:content'
+import PostCard from "@components/utilities/PostCard.astro";
+import General from "@layouts/General.astro";
+import { getCollection } from "astro:content";
 
-const posts = (await getCollection('blog')).sort((a, b) => a.data.pubDate.valueOf() - b.data.pubDate.valueOf())
+const posts = (await getCollection("blog")).sort(
+  (a, b) => a.data.pubDate.valueOf() - b.data.pubDate.valueOf(),
+);
 ---
 
 <General title="Blog" description="Blog post index">
-	<div class="my-5 grid grid-cols-2 gap-4">
-		{posts.map((post) => <PostCard {...post} />)}
-	</div>
+  <div class="my-5 grid grid-cols-2 gap-4">
+    {posts.map((post, index) => <PostCard {...post} eager={index < 2} />)}
+  </div>
 </General>

--- a/src/pages/sections/[id].astro
+++ b/src/pages/sections/[id].astro
@@ -1,60 +1,65 @@
 ---
-export const prerender = true
-import { getCollection } from 'astro:content'
-import General from '../../layouts/General.astro'
-import Section from '../../components/base/Section.astro'
-import PostCard from '@components/utilities/PostCard.astro'
+export const prerender = true;
+import { getCollection } from "astro:content";
+import General from "../../layouts/General.astro";
+import Section from "../../components/base/Section.astro";
+import PostCard from "@components/utilities/PostCard.astro";
 
 export async function getStaticPaths() {
-	const sections = await getCollection('sections')
-	return sections.map((section) => ({
-		params: { id: section.id },
-		props: { section }
-	}))
+  const sections = await getCollection("sections");
+  return sections.map((section) => ({
+    params: { id: section.id },
+    props: { section },
+  }));
 }
 
-const { section } = Astro.props
+const { section } = Astro.props;
 
 // Get child sections
-const allSections = await getCollection('sections')
-const childSections = allSections.filter((s) => s.data.parent === section.id)
+const allSections = await getCollection("sections");
+const childSections = allSections.filter((s) => s.data.parent === section.id);
 
 // Get blog posts for this section
-const allPosts = await getCollection('blog')
-const sectionPosts = allPosts.filter((post) => post.data.sections.id === section.id).sort((a, b) => b.data.pubDate.valueOf() - a.data.pubDate.valueOf())
+const allPosts = await getCollection("blog");
+const sectionPosts = allPosts
+  .filter((post) => post.data.sections.id === section.id)
+  .sort((a, b) => b.data.pubDate.valueOf() - a.data.pubDate.valueOf());
 ---
 
-<General title={`Section | ${section.data.name}`} description={`List of blog posts in the ${section.data.name} section.`}>
-	<div class="mx-auto max-w-4xl">
-		<section>
-			<h1>{section.data.name}</h1>
-			<p>{section.data.description}</p>
-		</section>
+<General
+  title={`Section | ${section.data.name}`}
+  description={`List of blog posts in the ${section.data.name} section.`}
+>
+  <div class="mx-auto max-w-4xl">
+    <section>
+      <h1>{section.data.name}</h1>
+      <p>{section.data.description}</p>
+    </section>
 
-		{
-			sectionPosts.length > 0 && (
-				<section>
-					<h2>Posts in this section</h2>
-					<ul class="grid grid-cols-2 gap-2">
-						{sectionPosts.map((post) => (
-							<PostCard {...post} class="col-span-1" />
-						))}
-					</ul>
-				</section>
-			)
-		}
+    {
+      sectionPosts.length > 0 && (
+        <section>
+          <h2>Posts in this section</h2>
+          <ul class="grid grid-cols-2 gap-2">
+            {sectionPosts.map((post, index) => (
+              <PostCard {...post} class="col-span-1" eager={index < 2} />
+            ))}
+          </ul>
+        </section>
+      )
+    }
 
-		{
-			childSections.length > 0 && (
-				<div>
-					<h2 class="mb-4 text-2xl font-bold">Subsections</h2>
-					<div class="space-y-6">
-						{childSections.map((childSection) => (
-							<Section {...childSection.data} />
-						))}
-					</div>
-				</div>
-			)
-		}
-	</div>
+    {
+      childSections.length > 0 && (
+        <div>
+          <h2 class="mb-4 text-2xl font-bold">Subsections</h2>
+          <div class="space-y-6">
+            {childSections.map((childSection) => (
+              <Section {...childSection.data} />
+            ))}
+          </div>
+        </div>
+      )
+    }
+  </div>
 </General>

--- a/src/pages/tags/[id].astro
+++ b/src/pages/tags/[id].astro
@@ -1,37 +1,42 @@
 ---
-export const prerender = true
-import { getCollection } from 'astro:content'
-import General from '../../layouts/General.astro'
-import PostCard from '@components/utilities/PostCard.astro'
+export const prerender = true;
+import { getCollection } from "astro:content";
+import General from "../../layouts/General.astro";
+import PostCard from "@components/utilities/PostCard.astro";
 export async function getStaticPaths() {
-	const tags = await getCollection('tags')
-	return tags.map((tag) => ({
-		params: { id: tag.id },
-		props: { tag }
-	}))
+  const tags = await getCollection("tags");
+  return tags.map((tag) => ({
+    params: { id: tag.id },
+    props: { tag },
+  }));
 }
 
-const { tag } = Astro.props
+const { tag } = Astro.props;
 
-const allPosts = await getCollection('blog')
-const posts = allPosts.filter((post) => post.data.tags.map((t) => t.id).includes(tag.id))
+const allPosts = await getCollection("blog");
+const posts = allPosts.filter((post) =>
+  post.data.tags.map((t) => t.id).includes(tag.id),
+);
 ---
 
-<General title={'Tag | ' + tag} description={'List of blog posts with the tag ' + tag}>
-	<section>
-		<h1>{tag.data.name}</h1>
-		<p>{tag.data.description}</p>
-		{
-			posts.length > 0 && (
-				<section>
-					<h2>Posts in this section</h2>
-					<ul class="grid grid-cols-2 gap-2">
-						{posts.map((post) => (
-							<PostCard {...post} class="col-span-1" />
-						))}
-					</ul>
-				</section>
-			)
-		}
-	</section>
+<General
+  title={"Tag | " + tag}
+  description={"List of blog posts with the tag " + tag}
+>
+  <section>
+    <h1>{tag.data.name}</h1>
+    <p>{tag.data.description}</p>
+    {
+      posts.length > 0 && (
+        <section>
+          <h2>Posts in this section</h2>
+          <ul class="grid grid-cols-2 gap-2">
+            {posts.map((post, index) => (
+              <PostCard {...post} class="col-span-1" eager={index < 2} />
+            ))}
+          </ul>
+        </section>
+      )
+    }
+  </section>
 </General>


### PR DESCRIPTION
💡 What: Introduced an `eager` prop to the `PostCard` component. This prop conditionally applies `loading="eager"` and `fetchpriority="high"` to the inner Astro `<Image>`. The prop is passed as true for the first two cards (`index < 2`) in the blog, tags, and sections index pages.
🎯 Why: Astro's `Image` component defaults to `loading="lazy"`. While excellent for below-the-fold content, this delays the loading of above-the-fold images. Eager loading these initial images significantly improves the Largest Contentful Paint (LCP) performance score.
📊 Impact: Faster rendering of the critical above-the-fold hero images across multiple key index pages.
🔬 Measurement: Verified the optimization locally using Playwright to confirm the DOM contains `loading="eager"` and `fetchpriority="high"` for the first row of images, and `loading="lazy"` for the rest. Visual verification confirmed no UI regressions.

---
*PR created automatically by Jules for task [3743575437680206843](https://jules.google.com/task/3743575437680206843) started by @jgeofil*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Images on blog, section, and tags pages now load with higher priority for faster initial display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->