### PR TITLE
⚡ Bolt: Optimize LCP with eager loading for above-the-fold PostCard images

### DIFF
--- a/src/components/utilities/PostCard.astro
+++ b/src/components/utilities/PostCard.astro
@@ -5,14 +5,15 @@ import Avatar from '@components/base/Avatar.astro'
 import Tag from '@components/base/Tag.astro'
 import { Image } from 'astro:assets'
 
-const { id, data } = Astro.props
+const { id, data, eagerLoad = false } = Astro.props
 
 const postTags = await getEntries<'tags'>(data.tags)
 const section = await getEntry('sections', data.sections.id)
 ---
 
 <div class="max-w-2xl overflow-hidden rounded-lg bg-white shadow-md">
-	<Image class="h-64 w-full object-cover" src={data.cover.src} alt={data.cover.alt} />
+	<!-- ⚡ Bolt Optimization: Eager load above-the-fold PostCard images for faster LCP -->
+	<Image class="h-64 w-full object-cover" src={data.cover.src} alt={data.cover.alt} loading={eagerLoad ? "eager" : "lazy"} fetchpriority={eagerLoad ? "high" : "auto"} />
 
 	<div class="p-6">
 		<div>

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -8,6 +8,6 @@ const posts = (await getCollection('blog')).sort((a, b) => a.data.pubDate.valueO
 
 <General title="Blog" description="Blog post index">
 	<div class="my-5 grid grid-cols-2 gap-4">
-		{posts.map((post) => <PostCard {...post} />)}
+		{posts.map((post, index) => <PostCard {...post} eagerLoad={index < 2} />)}
 	</div>
 </General>

--- a/src/pages/sections/[id].astro
+++ b/src/pages/sections/[id].astro
@@ -36,8 +36,8 @@ const sectionPosts = allPosts.filter((post) => post.data.sections.id === section
 				<section>
 					<h2>Posts in this section</h2>
 					<ul class="grid grid-cols-2 gap-2">
-						{sectionPosts.map((post) => (
-							<PostCard {...post} class="col-span-1" />
+						{sectionPosts.map((post, index) => (
+							<PostCard {...post} class="col-span-1" eagerLoad={index < 2} />
 						))}
 					</ul>
 				</section>

--- a/src/pages/tags/[id].astro
+++ b/src/pages/tags/[id].astro
@@ -26,8 +26,8 @@ const posts = allPosts.filter((post) => post.data.tags.map((t) => t.id).includes
 				<section>
 					<h2>Posts in this section</h2>
 					<ul class="grid grid-cols-2 gap-2">
-						{posts.map((post) => (
-							<PostCard {...post} class="col-span-1" />
+						{posts.map((post, index) => (
+							<PostCard {...post} class="col-span-1" eagerLoad={index < 2} />
 						))}
 					</ul>
 				</section>


### PR DESCRIPTION
💡 **What:** Added an `eagerLoad` prop to the `PostCard` component. This prop explicitly sets `loading="eager"` and `fetchpriority="high"` on the Astro `<Image />` component. We pass `eagerLoad={index < 2}` to the first row of images in the blog, sections, and tags list views.
🎯 **Why:** Astro's `<Image />` component defaults to `loading="lazy"`. While great for below-the-fold content, this delays the loading of critical above-the-fold images (like the first few post cards), negatively impacting the Largest Contentful Paint (LCP) metric.
📊 **Impact:** Expected to significantly improve LCP times on index/list pages by prioritizing the download of the first visible images, reducing the time users wait to see the primary content.
🔬 **Measurement:** Verify by running a Lighthouse audit or checking the network tab in DevTools. The first two images in the grid should be requested immediately with high priority, rather than waiting for the layout to finish calculating their visibility.

---
*PR created automatically by Jules for task [2374043342004625140](https://jules.google.com/task/2374043342004625140) started by @jgeofil*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Optimized image loading across post-listing pages, with featured posts now loading images eagerly while others load on-demand.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->