### PR TITLE
feat: Add PostHog integration

### DIFF
--- a/src/components/posthog.astro
+++ b/src/components/posthog.astro
@@ -1,0 +1,9 @@
+---
+---
+<script is:inline>
+    !function(t,e){var o,n,p,r;e.__SV||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.async=!0,p.src=s.api_host.replace(".i.posthog.com","-assets.i.posthog.com")+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(void 0!==a?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return"posthog"!==a&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString(1)+".people (stub)"},o="init capture register register_once register_for_session unregister opt_out_capturing has_opted_out_capturing opt_in_capturing reset isFeatureEnabled getFeatureFlag getFeatureFlagPayload reloadFeatureFlags group identify setPersonProperties setPersonPropertiesForFlags resetPersonPropertiesForFlags setGroupPropertiesForFlags resetGroupPropertiesForFlags resetGroups onFeatureFlags addFeatureFlagsHandler onSessionId getSurveys getActiveMatchingSurveys renderSurvey canRenderSurvey getNextSurveyStep".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a])},e.__SV=1)}(document,window.posthog||[]);
+    posthog.init('phc_2hPFUpij52BfVfbntuzOzo8UGqWwwzRPQcgsIjeK6Z5', {
+        api_host: 'https://us.i.posthog.com',
+        defaults: '2026-01-30'
+    })
+</script>

--- a/src/layouts/General.astro
+++ b/src/layouts/General.astro
@@ -3,6 +3,7 @@ import BaseHead from '@components/BaseHead.astro'
 import Header from '@components/Header.astro'
 import Footer from '@components/Footer.astro'
 import GTM from '@blocks/GTM.astro'
+import PostHogLayout from '../layouts/PostHogLayout.astro'
 interface Props {
 	title: string
 	description: string
@@ -11,6 +12,7 @@ interface Props {
 const { title, description } = Astro.props
 ---
 
+<PostHogLayout>
 <html lang="en">
 	<head>
 		<BaseHead title={title} description={description} />
@@ -27,3 +29,4 @@ const { title, description } = Astro.props
 		<Footer />
 	</body>
 </html>
+</PostHogLayout>

--- a/src/layouts/PostHogLayout.astro
+++ b/src/layouts/PostHogLayout.astro
@@ -1,0 +1,7 @@
+---
+import PostHog from '../components/posthog.astro'
+---
+<head>
+    <PostHog />
+</head>
+<slot />


### PR DESCRIPTION
Added PostHog snippet component `posthog.astro`.
Created a layout component `PostHogLayout.astro` that includes the snippet in the `<head>`.
Wrapped the main application wrapper layout `General.astro` with `PostHogLayout` to ensure the tracking script is active on all pages.

---
*PR created automatically by Jules for task [1089854752113983189](https://jules.google.com/task/1089854752113983189) started by @jgeofil*