### PR TITLE
🛡️ Sentinel: [security improvement] Add noreferrer to external link in privacy.astro

### DIFF
--- a/src/pages/privacy.astro
+++ b/src/pages/privacy.astro
@@ -83,7 +83,7 @@ import Layout from '@layouts/General.astro'
 		</li>
 		<li>
 			<p>
-				<strong>Website</strong> refers to ML Readme, accessible from <a href="mlread.me" rel="external nofollow noopener" target="_blank">mlread.me</a>
+				<strong>Website</strong> refers to ML Readme, accessible from <a href="mlread.me" rel="external nofollow noopener noreferrer" target="_blank">mlread.me</a>
 			</p>
 		</li>
 		<li>


### PR DESCRIPTION
🚨 **Severity**: MEDIUM
💡 **Vulnerability**: An external link in `privacy.astro` was missing the `noreferrer` attribute within its `rel` property. While `noopener` was already there, preventing reverse tabnabbing, adding `noreferrer` prevents the browser from sending the `Referer` header to the destination site.
🎯 **Impact**: Potential leakage of user's referrer information to the external site.
🔧 **Fix**: Added the `noreferrer` attribute to the `rel` property on the external link in `src/pages/privacy.astro`.
✅ **Verification**: Run `bun run lint` and verify no remaining links have `target="_blank"` without `rel="noopener noreferrer"`. Played back local frontend and verified link attributes.

---
*PR created automatically by Jules for task [4645643386598171227](https://jules.google.com/task/4645643386598171227) started by @jgeofil*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced security attributes for external links on the privacy page to improve referrer protection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->