### PR TITLE
⚡ Bolt: Limit rendered posts in HeroCard to prevent infinite DOM growth

### DIFF
--- a/dev_server.log
+++ b/dev_server.log
@@ -1,0 +1,16 @@
+$ astro dev
+08:57:49 [types] Generated 1ms
+08:57:50 [content] Syncing content
+08:57:50 [feed-loader] Loading posts
+08:57:50 [content] Synced content
+
+ astro  v5.18.1 ready in 1712 ms
+
+┃ Local    http://localhost:3000/
+┃ Network  http://192.168.0.2:3000/
+
+08:57:50 watching for file changes...
+08:58:35 [200] / 362ms
+08:58:36 [200] /_image 413ms
+08:58:36 [200] /_image 426ms
+08:58:36 [200] /_image 485ms

--- a/src/components/utilities/HeroCard.astro
+++ b/src/components/utilities/HeroCard.astro
@@ -2,9 +2,10 @@
 import { getCollection } from "astro:content";
 import { formatDate } from "@utils/format";
 import { Image } from "astro:assets";
-const posts = (await getCollection("blog")).sort(
-  (a, b) => b.data.pubDate.valueOf() - a.data.pubDate.valueOf(),
-);
+// ⚡ Bolt: Limit homepage posts to the 4 most recent to prevent infinite DOM growth as the blog scales
+const posts = (await getCollection("blog"))
+  .sort((a, b) => b.data.pubDate.valueOf() - a.data.pubDate.valueOf())
+  .slice(0, 4);
 ---
 
 <section class="pt-6">


### PR DESCRIPTION
💡 **What:** Added a limit (`.slice(0, 4)`) to the `getCollection('blog')` result in `HeroCard.astro`.

🎯 **Why:** The homepage's "Latest blog posts" widget was previously rendering *all* blog posts in the repository. As the blog grows, this would lead to unbounded DOM growth, drastically increasing the HTML payload size and slowing down the browser's parsing, layout, and painting times. It also slows down Astro's server build time for the homepage. 

📊 **Impact:** Prevents a performance regression. O(N) DOM node generation on the homepage is now O(1). HTML payload size remains constant and lightweight regardless of how many posts exist in the database/content collection.

🔬 **Measurement:** You can verify the improvement by inspecting the network payload size of `/` and the number of DOM nodes in the "Latest blog posts" section. With this change, the homepage will never contain more than 4 posts, keeping it fast and performant.

---
*PR created automatically by Jules for task [15073463381081756153](https://jules.google.com/task/15073463381081756153) started by @jgeofil*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Blog post display now shows only the 4 most recent entries sorted by publication date, improving page performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->