### PR TITLE
🛡️ Sentinel: [security improvement]

### DIFF
--- a/src/pages/privacy.astro
+++ b/src/pages/privacy.astro
@@ -83,7 +83,7 @@ import Layout from '@layouts/General.astro'
 		</li>
 		<li>
 			<p>
-				<strong>Website</strong> refers to ML Readme, accessible from <a href="mlread.me" rel="external nofollow noopener" target="_blank">mlread.me</a>
+				<strong>Website</strong> refers to ML Readme, accessible from <a href="https://mlread.me" rel="external nofollow noopener noreferrer" target="_blank">mlread.me</a>
 			</p>
 		</li>
 		<li>


### PR DESCRIPTION
🚨 **Severity:** LOW

💡 **Vulnerability:** The `privacy.astro` page contained an external link with `target="_blank"`. It was missing the `noreferrer` attribute and the link's href was specified as a relative URL `mlread.me` without the secure scheme (`https://`).
🎯 **Impact:** Leaving off `noreferrer` on external links can expose the application to reverse tabnabbing and referrer leakage. Also, missing the HTTPS protocol can result in a relative link resolving incorrectly, or insecure traffic routing.
🔧 **Fix:** Added `noreferrer` to the existing `rel` attribute, and added `https://` to the `href` attribute.
✅ **Verification:** Ran linters, tests, and visual frontend verification to ensure there were no regressions and everything still looks and works correctly.

---
*PR created automatically by Jules for task [5585612014668672969](https://jules.google.com/task/5585612014668672969) started by @jgeofil*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the website link in the privacy policy, ensuring it directs to the correct web address. Improved the link's security and privacy attributes to provide enhanced protection when users open it in a new browser tab.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->