### PR TITLE
⚡ Bolt: Prevent unbounded DOM growth in recent posts

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -11,3 +11,7 @@
 ## 2026-03-26 - Adding Eager Loading to Above-The-Fold Images
 **Learning:** Astro's `Image` component natively supports `loading="eager"` and `fetchpriority="high"`, but this is frequently forgotten on main entry points and list elements like article cards or the top image in a list. When images represent Largest Contentful Paint (LCP) and are displayed immediately, failing to add these attributes can have a big impact on LCP scores.
 **Action:** Always check components containing `Image` elements, particularly hero banners, avatars, or lists of cards, to see if they can benefit from `loading="eager"` and `fetchpriority="high"` for the initial/first items to improve the critical rendering path.
+
+## 2023-10-24 - Slice Astro collections to prevent O(N) rendering bottlenecks
+**Learning:** When fetching content collections (e.g., `getCollection('blog')`) for views that only display a few items (like 'recent posts' components on the home page), the entire collection is returned. If not immediately sliced, the framework iterates over or stores the full N array, and subsequent `.map()` calls can lead to unbounded DOM growth and severe performance degradation as the collection scales.
+**Action:** Always slice or limit the array immediately (e.g., `.slice(0, 4)`) after fetching and sorting to constrain processing and DOM elements to O(1) instead of O(N).

--- a/src/components/utilities/HeroCard.astro
+++ b/src/components/utilities/HeroCard.astro
@@ -2,9 +2,11 @@
 import { getCollection } from "astro:content";
 import { formatDate } from "@utils/format";
 import { Image } from "astro:assets";
-const posts = (await getCollection("blog")).sort(
-  (a, b) => b.data.pubDate.valueOf() - a.data.pubDate.valueOf(),
-);
+// ⚡ Bolt Optimization: Slicing the sorted collection limits the array to 4 items immediately
+// preventing O(N) operations and unbounded DOM growth as the blog collection scales.
+const posts = (await getCollection("blog"))
+  .sort((a, b) => b.data.pubDate.valueOf() - a.data.pubDate.valueOf())
+  .slice(0, 4);
 ---
 
 <section class="pt-6">


### PR DESCRIPTION
**💡 What**: Added a `.slice(0, 4)` directly to the `getCollection("blog")` fetch inside `src/components/utilities/HeroCard.astro` to cap the number of items early.

**🎯 Why**: The previous implementation fetched and sorted the entire content collection for the "recent blog posts" list. If the application maps over all returned items, this leads to an O(N) operation and unbounded DOM growth as the amount of content scales. Limiting it directly after the fetch optimizes memory usage and prevents the DOM rendering loop from scaling with the total collection size.

**📊 Impact**: Restricts the returned `posts` array in `HeroCard.astro` to 4 items (O(1)). Eliminates unbounded rendering loops related to the total blog collection size, reducing the risk of rendering bottlenecks and bloated DOM structures on pages using this component (like `index.astro`).

**🔬 Measurement**: To verify the improvement, you can measure total DOM elements on the index page (`document.querySelectorAll('*').length`) or observe Memory allocation in Chrome DevTools during page load before and after adding a large number of dummy `.md` content files in `src/content/blog/`.

---
*PR created automatically by Jules for task [1979899846759000110](https://jules.google.com/task/1979899846759000110) started by @jgeofil*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Optimized the blog section to display the 4 most recent posts, improving page load and rendering performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->