### PR TITLE
⚡ Bolt: Use .some() instead of .map().includes() for tag filtering

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -11,3 +11,7 @@
 ## 2026-03-26 - Adding Eager Loading to Above-The-Fold Images
 **Learning:** Astro's `Image` component natively supports `loading="eager"` and `fetchpriority="high"`, but this is frequently forgotten on main entry points and list elements like article cards or the top image in a list. When images represent Largest Contentful Paint (LCP) and are displayed immediately, failing to add these attributes can have a big impact on LCP scores.
 **Action:** Always check components containing `Image` elements, particularly hero banners, avatars, or lists of cards, to see if they can benefit from `loading="eager"` and `fetchpriority="high"` for the initial/first items to improve the critical rendering path.
+
+## 2024-04-02 - Prefer .some() over .map().includes() for array matching
+**Learning:** Checking for inclusion in an array of objects by mapping properties first (e.g., `arr.map(x => x.id).includes(target)`) causes unnecessary memory allocations by creating an intermediate array and iterates through elements twice (first for mapping, then for checking inclusion). This is inefficient, especially when scaling up data.
+**Action:** Always prefer `.some()` (e.g., `arr.some(x => x.id === target)`) over `.map().includes()`. It stops execution early once a match is found and avoids allocating memory for a new intermediate array, ensuring both better speed and lower memory usage.

--- a/src/pages/tags/[id].astro
+++ b/src/pages/tags/[id].astro
@@ -15,7 +15,8 @@ const { tag } = Astro.props;
 
 const allPosts = await getCollection("blog");
 const posts = allPosts.filter((post) =>
-  post.data.tags.map((t) => t.id).includes(tag.id),
+  // ⚡ Bolt Optimization: Use .some() instead of .map().includes() to prevent intermediate array allocation and allow for early exit
+  post.data.tags.some((t: { id: string }) => t.id === tag.id),
 );
 ---
 


### PR DESCRIPTION
### 💡 What
Replaced `.map(t => t.id).includes(target)` with `.some(t => t.id === target)` inside the array filtering logic for tag routing (`src/pages/tags/[id].astro`).

### 🎯 Why
Checking for inclusion in an array of objects by mapping properties first causes unnecessary memory allocations by creating an intermediate array and iterates through elements twice (first for mapping, then for checking inclusion). This is inefficient, especially when scaling up data or when running loops inside loops (like filtering posts by tags). 

Using `.some()` stops execution early once a match is found and avoids allocating memory for a new array, ensuring both better speed and lower memory usage during Static Site Generation (SSG) of Astro pages.

### 📊 Impact
*   Reduces memory allocations during the static rendering loop of tags.
*   Lowers algorithmic complexity overhead, allowing the search inner loop to short-circuit and early exit.

### 🔬 Measurement
Tests were run via `SUPABASE_URL="http://localhost:5432" SUPABASE_KEY="anon" bun run test --project=chromium` and passed successfully. No regressions found. Linting passes.

---
*PR created automatically by Jules for task [17274499197027345925](https://jules.google.com/task/17274499197027345925) started by @jgeofil*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized internal filtering performance to improve application responsiveness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->