### PR TITLE
⚡ Bolt: Parallelize independent async data fetching

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -15,3 +15,7 @@
 ## 2024-04-02 - Prefer .some() over .map().includes() for array matching
 **Learning:** Checking for inclusion in an array of objects by mapping properties first (e.g., `arr.map(x => x.id).includes(target)`) causes unnecessary memory allocations by creating an intermediate array and iterates through elements twice (first for mapping, then for checking inclusion). This is inefficient, especially when scaling up data.
 **Action:** Always prefer `.some()` (e.g., `arr.some(x => x.id === target)`) over `.map().includes()`. It stops execution early once a match is found and avoids allocating memory for a new intermediate array, ensuring both better speed and lower memory usage.
+
+## 2024-05-15 - Reduce Waterfall Latency with Promise.all()
+**Learning:** Sequential `await` calls for independent data fetching operations (like `getEntry`, `getEntries`, and `getCollection`) in Astro components cause unnecessary waterfall latency and delay the First Byte response.
+**Action:** Always parallelize independent asynchronous data fetching using `Promise.all()` to ensure they run concurrently, reducing overall rendering time without changing the component's output.

--- a/src/components/PostMetadata.astro
+++ b/src/components/PostMetadata.astro
@@ -1,43 +1,64 @@
 ---
-export const prerender = false
-import { getEntry } from 'astro:content'
-import Tag from '@components/base/Tag.astro'
-import { formatDate } from '@utils/format'
-import { getEntries } from 'astro:content'
+export const prerender = false;
+import { getEntry } from "astro:content";
+import Tag from "@components/base/Tag.astro";
+import { formatDate } from "@utils/format";
+import { getEntries } from "astro:content";
 
-const { title, tags, sections, pubDate, dateUpdated, foreword } = Astro.props
-const postTags = await getEntries<'tags'>(tags)
-const sectionData = await getEntry('sections', sections.id)
+const { title, tags, sections, pubDate, dateUpdated, foreword } = Astro.props;
+
+// ⚡ Bolt Optimization: Parallelize independent async data fetching to reduce waterfall latency
+const [postTags, sectionData] = await Promise.all([
+  getEntries<"tags">(tags),
+  getEntry("sections", sections.id),
+]);
 ---
 
 <div class="radient2 mx-auto mb-6 h-auto w-screen">
-	<div class="mx-auto px-6 py-8 md:container md:max-w-5xl">
-		<h1>{title}</h1>
-		<div class="contents text-xs">
-			<div class="block">{formatDate(pubDate)}</div>{dateUpdated && <div class="block">{'Updated: ' + formatDate(dateUpdated)}</div>}
-		</div>
-		<div class="block py-2">{sectionData.data.name}</div>
-	</div>
+  <div class="mx-auto px-6 py-8 md:container md:max-w-5xl">
+    <h1>{title}</h1>
+    <div class="contents text-xs">
+      <div class="block">{formatDate(pubDate)}</div>{
+        dateUpdated && (
+          <div class="block">{"Updated: " + formatDate(dateUpdated)}</div>
+        )
+      }
+    </div>
+    <div class="block py-2">{sectionData.data.name}</div>
+  </div>
 </div>
 <div class="mx-auto my-6 px-6 py-2 md:container md:max-w-5xl">
-	<div class="flex flex-col">
-		<p class="text-lg font-light">{foreword}</p>
-	</div>
-	<div class="flex flex-col">
-		<div class="block">
-			{postTags.map((tag) => <Tag class={tag.data.color} {...tag.data} />)}
-		</div>
-	</div>
+  <div class="flex flex-col">
+    <p class="text-lg font-light">{foreword}</p>
+  </div>
+  <div class="flex flex-col">
+    <div class="block">
+      {postTags.map((tag) => <Tag class={tag.data.color} {...tag.data} />)}
+    </div>
+  </div>
 </div>
 
 <style lang="scss">
-	@use 'sass:math';
-	.radient {
-		background-image: url(https://grainy-gradients.vercel.app/noise.svg),
-			radial-gradient(at left top, rgb(50, 100, math.random(255)), rgb(50, 200, math.random(255)), rgb(50, 150, math.random(255)));
-	}
-	.radient2 {
-		/* Gradient in Hex */
-		background-image: radial-gradient(at right bottom, #013668 0%, 30%, #789a8a 60%, 80%, #ffffff 100%);
-	}
+  @use "sass:math";
+  .radient {
+    background-image:
+      url(https://grainy-gradients.vercel.app/noise.svg),
+      radial-gradient(
+        at left top,
+        rgb(50, 100, math.random(255)),
+        rgb(50, 200, math.random(255)),
+        rgb(50, 150, math.random(255))
+      );
+  }
+  .radient2 {
+    /* Gradient in Hex */
+    background-image: radial-gradient(
+      at right bottom,
+      #013668 0%,
+      30%,
+      #789a8a 60%,
+      80%,
+      #ffffff 100%
+    );
+  }
 </style>

--- a/src/components/utilities/PostCard.astro
+++ b/src/components/utilities/PostCard.astro
@@ -7,8 +7,11 @@ import { Image } from "astro:assets";
 
 const { id, data, eager = false } = Astro.props;
 
-const postTags = await getEntries<"tags">(data.tags);
-const section = await getEntry("sections", data.sections.id);
+// ⚡ Bolt Optimization: Parallelize independent async data fetching to reduce waterfall latency
+const [postTags, section] = await Promise.all([
+  getEntries<"tags">(data.tags),
+  getEntry("sections", data.sections.id),
+]);
 ---
 
 <div class="max-w-2xl overflow-hidden rounded-lg bg-white shadow-md">

--- a/src/pages/sections/[id].astro
+++ b/src/pages/sections/[id].astro
@@ -15,12 +15,16 @@ export async function getStaticPaths() {
 
 const { section } = Astro.props;
 
+// ⚡ Bolt Optimization: Parallelize independent collection fetching to avoid waterfall delays
+const [allSections, allPosts] = await Promise.all([
+  getCollection("sections"),
+  getCollection("blog"),
+]);
+
 // Get child sections
-const allSections = await getCollection("sections");
 const childSections = allSections.filter((s) => s.data.parent === section.id);
 
 // Get blog posts for this section
-const allPosts = await getCollection("blog");
 const sectionPosts = allPosts
   .filter((post) => post.data.sections.id === section.id)
   .sort((a, b) => b.data.pubDate.valueOf() - a.data.pubDate.valueOf());


### PR DESCRIPTION
**💡 What:** We parallelized independent asynchronous data fetching calls in `PostCard.astro`, `PostMetadata.astro`, and `sections/[id].astro` by wrapping them in `Promise.all()`.

**🎯 Why:** In multiple Astro components and pages, data like tags and section info were being fetched sequentially (waterfall latency). Since these queries do not depend on each other, they can and should be executed concurrently.

**📊 Impact:** This reduces the total time required to fetch data for these components. Instead of `T1 + T2`, the data loading time becomes `max(T1, T2)`. This creates a measurable reduction in server-rendering time and builds without altering application functionality or deleting expected content.

**🔬 Measurement:** View any post or section page locally. The First Byte latency is reduced since multiple collections or entries are now read simultaneously from disk (during the build) rather than sequentially. The visual output and UI behavior remain exactly the same.

---
*PR created automatically by Jules for task [1465137719210646925](https://jules.google.com/task/1465137719210646925) started by @jgeofil*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added performance-focused guidelines for managing asynchronous data operations in Astro components

* **Refactor**
  * Updated asynchronous data fetching patterns across multiple components to execute operations concurrently
  * Standardized code formatting and structure for consistency

<!-- end of auto-generated comment: release notes by coderabbit.ai -->