### PR TITLE
⚡ Bolt: Omit quality="max" on LCP banner image

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,21 +1,31 @@
 # BOLT'S JOURNAL - CRITICAL LEARNINGS ONLY
 
+## 2024-05-28 - Avoid forcing max quality on LCP images in Astro
+
+**Learning:** Forcing `quality="max"` on large Astro `<Image>` components, particularly hero images or banners used as LCP elements, disables the default compression and leads to massive payload sizes, hurting performance significantly.
+**Action:** Omit the `quality` attribute on large above-the-fold or LCP `<Image>` components to allow Astro to apply sensible default web compression and significantly reduce download sizes.
+
 ## 2025-01-20 - Optimize LCP for Astro Image components
 
 **Learning:** Astro's built-in `<Image />` component sets `loading="lazy"` and `decoding="async"` by default. While excellent for below-the-fold content, this negatively impacts the Largest Contentful Paint (LCP) when used for critical above-the-fold images (like banners or hero sections).
 **Action:** Always identify above-the-fold images and explicitly set `loading="eager"` and `fetchpriority="high"` on the Astro `<Image />` component to prioritize their loading.
+
 ## 2024-05-23 - [Date Formatting Bottleneck]
+
 **Learning:** `Date.toLocaleDateString` is shockingly slow when called repeatedly (e.g., rendering a list of blog posts) because it instantiates a new `Intl.DateTimeFormat` object each time. A benchmark showed unoptimized taking ~730ms vs optimized taking ~2ms for 1000 dates.
 **Action:** When formatting multiple dates, cache the `Intl.DateTimeFormat` instance globally and reuse its `.format(date)` method instead of calling `.toLocaleDateString()` directly on the Date instances.
 
 ## 2026-03-26 - Adding Eager Loading to Above-The-Fold Images
+
 **Learning:** Astro's `Image` component natively supports `loading="eager"` and `fetchpriority="high"`, but this is frequently forgotten on main entry points and list elements like article cards or the top image in a list. When images represent Largest Contentful Paint (LCP) and are displayed immediately, failing to add these attributes can have a big impact on LCP scores.
 **Action:** Always check components containing `Image` elements, particularly hero banners, avatars, or lists of cards, to see if they can benefit from `loading="eager"` and `fetchpriority="high"` for the initial/first items to improve the critical rendering path.
 
 ## 2024-04-02 - Prefer .some() over .map().includes() for array matching
+
 **Learning:** Checking for inclusion in an array of objects by mapping properties first (e.g., `arr.map(x => x.id).includes(target)`) causes unnecessary memory allocations by creating an intermediate array and iterates through elements twice (first for mapping, then for checking inclusion). This is inefficient, especially when scaling up data.
 **Action:** Always prefer `.some()` (e.g., `arr.some(x => x.id === target)`) over `.map().includes()`. It stops execution early once a match is found and avoids allocating memory for a new intermediate array, ensuring both better speed and lower memory usage.
 
 ## 2024-05-15 - Reduce Waterfall Latency with Promise.all()
+
 **Learning:** Sequential `await` calls for independent data fetching operations (like `getEntry`, `getEntries`, and `getCollection`) in Astro components cause unnecessary waterfall latency and delay the First Byte response.
 **Action:** Always parallelize independent asynchronous data fetching using `Promise.all()` to ensure they run concurrently, reducing overall rendering time without changing the component's output.

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -9,11 +9,11 @@ import banner from "public/images/banner.png";
 
 <General title={SITE_TITLE} , description={SITE_DESCRIPTION}>
   <!-- ⚡ Bolt Optimization: Eager load banner image for faster LCP -->
+  <!-- ⚡ Bolt Optimization: Omit quality="max" to enable default web compression, drastically reducing LCP payload size -->
   <Image
     class="w-screen"
     slot="head-slot"
     src={banner}
-    quality="max"
     alt="ML Readme Logo"
     loading="eager"
     fetchpriority="high"


### PR DESCRIPTION
### 💡 What
Removed the `quality="max"` attribute from the primary hero/banner `<Image>` component in `src/pages/index.astro`. 

### 🎯 Why
Setting `quality="max"` on large Astro `<Image>` components forces lossless, high-quality rendering, which disables Astro's built-in web compression. For above-the-fold images that act as the Largest Contentful Paint (LCP) element, this results in massive payload sizes and significantly delays the critical rendering path.

### 📊 Impact
Omitting the attribute allows Astro to compress the image into modern web formats (like WebP) with sensible defaults (~80% quality). This drastically reduces the total bytes transferred over the network without noticeably degrading visual fidelity, directly improving the LCP metric.

### 🔬 Measurement
Verify the improvement by profiling the network tab in browser dev tools on the index page. The `banner.png` file should be served as a compressed image format with a significantly smaller file size compared to the unoptimized baseline. Playwright tests and lint checks continue to pass successfully.

---
*PR created automatically by Jules for task [8053491949314811871](https://jules.google.com/task/8053491949314811871) started by @jgeofil*