### PR TITLE
🎨 Palette: Add aria-current to active navigation links

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-18 - Pairing Visual States with `aria-current`
+**Learning:** In Astro components, active navigation items are often styled visually (e.g. `border-b-4`), but this is invisible to screen readers without standard attributes.
+**Action:** When creating or modifying navigation links (`<HeaderLink>`), always pair the visual active state with `aria-current="page"` to ensure screen reader users understand their current context within the site navigation.

--- a/src/components/base/HeaderLink.astro
+++ b/src/components/base/HeaderLink.astro
@@ -1,10 +1,19 @@
 ---
-const { href, class: className, ...props } = Astro.props
-const { pathname } = Astro.url
-const subpath = pathname.match(/[^\/]+/g)
-const isActive = href === pathname || href === '/' + subpath?.[0]
+const { href, class: className, ...props } = Astro.props;
+const { pathname } = Astro.url;
+const subpath = pathname.match(/[^\/]+/g);
+const isActive = href === pathname || href === "/" + subpath?.[0];
 ---
 
-<a href={href} class:list={[className, { 'border-b-4': isActive }, 'active: inline-block border-solid border-black p-4']} {...props}>
-	<slot />
+<a
+  href={href}
+  aria-current={isActive ? "page" : undefined}
+  class:list={[
+    className,
+    { "border-b-4": isActive },
+    "active: inline-block border-solid border-black p-4",
+  ]}
+  {...props}
+>
+  <slot />
 </a>


### PR DESCRIPTION
### 💡 What
Added `aria-current="page"` attribute to the `<HeaderLink>` component when the link is active.

### 🎯 Why
Currently, active navigation links are indicated purely visually with a bottom border (`border-b-4`). This change ensures that screen reader users are also provided with the semantic context of their current location within the site navigation.

### ♿ Accessibility
- Provides screen reader support for the active page context, pairing the visual active state with the standard semantic attribute.
- Uses conditional assignment (`aria-current={isActive ? "page" : undefined}`) to cleanly omit the attribute when inactive.

*(Note: Changes also include a new Palette learning journal entry `.jules/palette.md` for this accessibility pattern.)*

---
*PR created automatically by Jules for task [12198959976882400082](https://jules.google.com/task/12198959976882400082) started by @jgeofil*