### PR TITLE
⚡ Bolt: Optimize build time by fetching collections in getStaticPaths

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -29,3 +29,8 @@
 
 **Learning:** Sequential `await` calls for independent data fetching operations (like `getEntry`, `getEntries`, and `getCollection`) in Astro components cause unnecessary waterfall latency and delay the First Byte response.
 **Action:** Always parallelize independent asynchronous data fetching using `Promise.all()` to ensure they run concurrently, reducing overall rendering time without changing the component's output.
+
+## 2025-01-20 - Fetch Collections in getStaticPaths for SSG Build Optimization
+
+**Learning:** When generating multiple static pages using `getStaticPaths` (like `/tags/[id]` or `/sections/[id]`), calling `getCollection()` in the component body fetches and filters the entire collection for *every single generated page*. This changes build time complexity to O(N²), slowing down the build significantly as data scales.
+**Action:** Always fetch the entire required collections inside `getStaticPaths()` exactly once, perform any necessary iteration or filtering there, and pass the specific subsets or related items to the Astro component via `props`. This reduces the build complexity to O(N).

--- a/src/pages/sections/[id].astro
+++ b/src/pages/sections/[id].astro
@@ -6,28 +6,33 @@ import Section from "../../components/base/Section.astro";
 import PostCard from "@components/utilities/PostCard.astro";
 
 export async function getStaticPaths() {
-  const sections = await getCollection("sections");
-  return sections.map((section) => ({
-    params: { id: section.id },
-    props: { section },
-  }));
+  // ⚡ Bolt Optimization: Move collection fetching and filtering into getStaticPaths.
+  // This changes build complexity from O(N^2) to O(N) by fetching the entire collection
+  // only once per build rather than once per generated page.
+  const [allSections, allPosts] = await Promise.all([
+    getCollection("sections"),
+    getCollection("blog"),
+  ]);
+
+  return allSections.map((section) => {
+    // Get child sections
+    const childSections = allSections.filter(
+      (s) => s.data.parent === section.id,
+    );
+
+    // Get blog posts for this section
+    const sectionPosts = allPosts
+      .filter((post) => post.data.sections.id === section.id)
+      .sort((a, b) => b.data.pubDate.valueOf() - a.data.pubDate.valueOf());
+
+    return {
+      params: { id: section.id },
+      props: { section, childSections, sectionPosts },
+    };
+  });
 }
 
-const { section } = Astro.props;
-
-// ⚡ Bolt Optimization: Parallelize independent collection fetching to avoid waterfall delays
-const [allSections, allPosts] = await Promise.all([
-  getCollection("sections"),
-  getCollection("blog"),
-]);
-
-// Get child sections
-const childSections = allSections.filter((s) => s.data.parent === section.id);
-
-// Get blog posts for this section
-const sectionPosts = allPosts
-  .filter((post) => post.data.sections.id === section.id)
-  .sort((a, b) => b.data.pubDate.valueOf() - a.data.pubDate.valueOf());
+const { section, childSections, sectionPosts } = Astro.props;
 ---
 
 <General

--- a/src/pages/tags/[id].astro
+++ b/src/pages/tags/[id].astro
@@ -4,20 +4,28 @@ import { getCollection } from "astro:content";
 import General from "../../layouts/General.astro";
 import PostCard from "@components/utilities/PostCard.astro";
 export async function getStaticPaths() {
-  const tags = await getCollection("tags");
-  return tags.map((tag) => ({
-    params: { id: tag.id },
-    props: { tag },
-  }));
+  // ⚡ Bolt Optimization: Move collection fetching and filtering into getStaticPaths.
+  // This changes build complexity from O(N^2) to O(N) by fetching the entire collection
+  // only once per build rather than once per generated page.
+  const [tags, allPosts] = await Promise.all([
+    getCollection("tags"),
+    getCollection("blog"),
+  ]);
+
+  return tags.map((tag) => {
+    const posts = allPosts.filter((post) =>
+      // ⚡ Bolt Optimization: Use .some() instead of .map().includes() to prevent intermediate array allocation and allow for early exit
+      post.data.tags.some((t: { id: string }) => t.id === tag.id),
+    );
+
+    return {
+      params: { id: tag.id },
+      props: { tag, posts },
+    };
+  });
 }
 
-const { tag } = Astro.props;
-
-const allPosts = await getCollection("blog");
-const posts = allPosts.filter((post) =>
-  // ⚡ Bolt Optimization: Use .some() instead of .map().includes() to prevent intermediate array allocation and allow for early exit
-  post.data.tags.some((t: { id: string }) => t.id === tag.id),
-);
+const { tag, posts } = Astro.props;
 ---
 
 <General


### PR DESCRIPTION
💡 **What**: Moved `getCollection` and subsequent filtering logic out of the Astro component body and directly into `getStaticPaths()` for the `/sections/[id].astro` and `/tags/[id].astro` files. Passed the pre-filtered items into the component via `props`.
🎯 **Why**: Previously, these SSG routes fetched the entire `blog`, `tags`, and `sections` collections repeatedly for *every single generated page*. This caused an O(N²) time complexity during builds, which noticeably impacted performance as the data scales.
📊 **Impact**: Reduces redundant database / file IO reads from O(N²) down to O(N) and prevents repeated redundant filtering. Build execution speed remains highly optimal even as dozens of tags and sections are added.
🔬 **Measurement**: Verified the reduction in memory and overhead using `bun run build`. Build completes optimally without waterfall execution. All automated formatting, linting, and Playwright tests continue to pass correctly.

---
*PR created automatically by Jules for task [8318776928198330813](https://jules.google.com/task/8318776928198330813) started by @jgeofil*