### PR TITLE
⚡ Bolt: Optimize SSG build complexity with O(1) hash map lookups

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -34,3 +34,8 @@
 
 **Learning:** When generating multiple static pages using `getStaticPaths` (like `/tags/[id]` or `/sections/[id]`), calling `getCollection()` in the component body fetches and filters the entire collection for *every single generated page*. This changes build time complexity to O(N²), slowing down the build significantly as data scales.
 **Action:** Always fetch the entire required collections inside `getStaticPaths()` exactly once, perform any necessary iteration or filtering there, and pass the specific subsets or related items to the Astro component via `props`. This reduces the build complexity to O(N).
+
+## 2025-01-20 - Replace O(N²) nested filtering with O(N) Hash Map lookups in SSG paths
+
+**Learning:** When using `getStaticPaths` to generate pages from content collections (like tags or categories), using `.filter()` inside the `.map()` loop creates an O(N²) complexity bottleneck that exponentially increases build times as content scales.
+**Action:** Always pre-process collections into a `Map` (Hash Map) *before* mapping over the paths. This allows for an O(1) lookup during the path generation loop, effectively reducing the time complexity from O(N²) to O(N).

--- a/src/pages/sections/[id].astro
+++ b/src/pages/sections/[id].astro
@@ -14,16 +14,33 @@ export async function getStaticPaths() {
     getCollection("blog"),
   ]);
 
+  // ⚡ Bolt Optimization: Replace O(N^2) nested loops with O(N) hash map lookups
+  const postsBySection = new Map();
+  for (const post of allPosts) {
+    const secId = post.data.sections.id;
+    if (!postsBySection.has(secId)) postsBySection.set(secId, []);
+    postsBySection.get(secId).push(post);
+  }
+
+  for (const posts of postsBySection.values()) {
+    posts.sort((a, b) => b.data.pubDate.valueOf() - a.data.pubDate.valueOf());
+  }
+
+  const childrenByParent = new Map();
+  for (const section of allSections) {
+    if (section.data.parent) {
+      if (!childrenByParent.has(section.data.parent))
+        childrenByParent.set(section.data.parent, []);
+      childrenByParent.get(section.data.parent).push(section);
+    }
+  }
+
   return allSections.map((section) => {
     // Get child sections
-    const childSections = allSections.filter(
-      (s) => s.data.parent === section.id,
-    );
+    const childSections = childrenByParent.get(section.id) || [];
 
     // Get blog posts for this section
-    const sectionPosts = allPosts
-      .filter((post) => post.data.sections.id === section.id)
-      .sort((a, b) => b.data.pubDate.valueOf() - a.data.pubDate.valueOf());
+    const sectionPosts = postsBySection.get(section.id) || [];
 
     return {
       params: { id: section.id },

--- a/src/pages/tags/[id].astro
+++ b/src/pages/tags/[id].astro
@@ -12,11 +12,17 @@ export async function getStaticPaths() {
     getCollection("blog"),
   ]);
 
+  // ⚡ Bolt Optimization: Replace O(N^2) nested loop with O(N) hash map lookup
+  const postsByTag = new Map();
+  for (const post of allPosts) {
+    for (const t of post.data.tags) {
+      if (!postsByTag.has(t.id)) postsByTag.set(t.id, []);
+      postsByTag.get(t.id).push(post);
+    }
+  }
+
   return tags.map((tag) => {
-    const posts = allPosts.filter((post) =>
-      // ⚡ Bolt Optimization: Use .some() instead of .map().includes() to prevent intermediate array allocation and allow for early exit
-      post.data.tags.some((t: { id: string }) => t.id === tag.id),
-    );
+    const posts = postsByTag.get(tag.id) || [];
 
     return {
       params: { id: tag.id },


### PR DESCRIPTION
💡 **What:** 
Replaced nested `.filter()` loops inside `getStaticPaths` mapping functions with pre-processed `Map` lookups in `src/pages/sections/[id].astro` and `src/pages/tags/[id].astro`.

🎯 **Why:** 
Previously, the `getStaticPaths` logic iterated over the entire `blog` collection inside a `.map()` block iterating over the `sections` or `tags` collections. This means for every tag and section being statically generated, Astro re-scanned the entire post array. This O(N²) architecture scales poorly and significantly slows down the SSG build phase as the amount of content increases. 

📊 **Impact:** 
*   **Time Complexity:** Reduced SSG path routing complexity from $O(N^2)$ to $O(N)$.
*   **Build Speed:** Significantly reduces the workload and memory allocation overhead during `bun run build`.

🔬 **Measurement:**
*   You can verify this fix by running the test suite and building the static site:
    *   `bun run build` ensures all static routing successfully completes.
    *   `bun run test` verifies there are no regressions to UI or endpoints.

---
*PR created automatically by Jules for task [3787979810747069220](https://jules.google.com/task/3787979810747069220) started by @jgeofil*